### PR TITLE
Add configurable leeway to verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
 end
 ```
 
+### Increasing Expiry leeway
+
+JWT tokens contain an expiry timestamp. If communication delays are large (or system clocks are sufficiently out of synch), you may need to increase the 'leeway' when verifying. For example:
+
+```ruby
+  JWTSignedRequest.verify(request: request, secret_key: 'my_public_key', leeway: 55)
+```
+
 ## Using Rack Middleware
 
 ```ruby

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -33,7 +33,7 @@ module JWTSignedRequest
   end
 
   def self.verify(request:, secret_key:, algorithm: nil, leeway: 0)
-    # algorithm is deprecated and will be removed in future
+    # TODO: algorithm is deprecated and will be removed in future
     verify = true
     jwt_token = Headers.fetch('Authorization', request)
 
@@ -42,10 +42,10 @@ module JWTSignedRequest
     end
 
     begin
-      #TODO Once JWT v2.0.0 has been released, we should upgrade to it and start using `exp_leeway` instead
-      # 'leeway' will still work, but 'exp_leeway' is more explicit and is the documented way to do it.
-      # see https://github.com/jwt/ruby-jwt/pull/187
-      claims = JWT.decode(jwt_token, secret_key, verify, {leeway: leeway.to_i})[0]
+      # TODO: Once JWT v2.0.0 has been released, we should upgrade to it and start using `exp_leeway` instead
+      #  'leeway' will still work, but 'exp_leeway' is more explicit and is the documented way to do it.
+      #  see https://github.com/jwt/ruby-jwt/pull/187
+      claims = JWT.decode(jwt_token, secret_key, verify, leeway: leeway.to_i)[0]
       unless verified_request?(request: request, claims: claims)
         raise RequestVerificationFailedError, "Request failed verification"
       end

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -32,7 +32,7 @@ module JWTSignedRequest
     )
   end
 
-  def self.verify(request:, secret_key:, algorithm: nil)
+  def self.verify(request:, secret_key:, algorithm: nil, leeway: 0)
     # algorithm is deprecated and will be removed in future
     jwt_token = Headers.fetch('Authorization', request)
 

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -32,9 +32,16 @@ module JWTSignedRequest
     )
   end
 
-  def self.verify(request:, secret_key:, algorithm: nil, leeway: 0)
+  def self.verify(request:, secret_key:, algorithm: nil, leeway: nil)
     # TODO: algorithm is deprecated and will be removed in future
     verify = true
+    options = {}
+    if leeway
+      # TODO: Once JWT v2.0.0 has been released, we should upgrade to it and start using `exp_leeway` instead
+      #  'leeway' will still work, but 'exp_leeway' is more explicit and is the documented way to do it.
+      #  see https://github.com/jwt/ruby-jwt/pull/187
+      options[:leeway] = leeway.to_i
+    end
     jwt_token = Headers.fetch('Authorization', request)
 
     if jwt_token.nil?
@@ -42,10 +49,7 @@ module JWTSignedRequest
     end
 
     begin
-      # TODO: Once JWT v2.0.0 has been released, we should upgrade to it and start using `exp_leeway` instead
-      #  'leeway' will still work, but 'exp_leeway' is more explicit and is the documented way to do it.
-      #  see https://github.com/jwt/ruby-jwt/pull/187
-      claims = JWT.decode(jwt_token, secret_key, verify, leeway: leeway.to_i)[0]
+      claims = JWT.decode(jwt_token, secret_key, verify, options)[0]
       unless verified_request?(request: request, claims: claims)
         raise RequestVerificationFailedError, "Request failed verification"
       end

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -42,6 +42,9 @@ module JWTSignedRequest
     end
 
     begin
+      #TODO Once JWT v2.0.0 has been released, we should upgrade to it and start using `exp_leeway` instead
+      # 'leeway' will still work, but 'exp_leeway' is more explicit and is the documented way to do it.
+      # see https://github.com/jwt/ruby-jwt/pull/187
       claims = JWT.decode(jwt_token, secret_key, verify, {leeway: leeway.to_i})[0]
       unless verified_request?(request: request, claims: claims)
         raise RequestVerificationFailedError, "Request failed verification"

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -34,6 +34,7 @@ module JWTSignedRequest
 
   def self.verify(request:, secret_key:, algorithm: nil, leeway: 0)
     # algorithm is deprecated and will be removed in future
+    verify = true
     jwt_token = Headers.fetch('Authorization', request)
 
     if jwt_token.nil?
@@ -41,7 +42,7 @@ module JWTSignedRequest
     end
 
     begin
-      claims = JWT.decode(jwt_token, secret_key)[0]
+      claims = JWT.decode(jwt_token, secret_key, verify, {leeway: leeway.to_i})[0]
       unless verified_request?(request: request, claims: claims)
         raise RequestVerificationFailedError, "Request failed verification"
       end

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -11,7 +11,11 @@ module JWTSignedRequest
   JWTDecodeError = Class.new(UnauthorizedRequestError)
   RequestVerificationFailedError = Class.new(UnauthorizedRequestError)
 
-  def self.sign(method:, path:, body: EMPTY_BODY, headers:, secret_key:, algorithm: DEFAULT_ALGORITHM, key_id: nil, issuer: nil, additional_headers_to_sign: Claims::EMPTY_HEADERS)
+  def self.sign(method:, path:,
+                body: EMPTY_BODY, headers:,
+                secret_key:, algorithm: DEFAULT_ALGORITHM,
+                key_id: nil, issuer: nil,
+                additional_headers_to_sign: Claims::EMPTY_HEADERS)
     additional_jwt_headers = key_id ? {kid: key_id} : {}
     JWT.encode(
       Claims.generate(

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -33,15 +33,15 @@ module JWTSignedRequest
   end
 
   def self.verify(request:, secret_key:, algorithm: nil)
+    # algorithm is deprecated and will be removed in future
     jwt_token = Headers.fetch('Authorization', request)
-    algorithm ||= DEFAULT_ALGORITHM
 
     if jwt_token.nil?
       raise MissingAuthorizationHeaderError, "Missing Authorization header in the request"
     end
 
     begin
-      claims = JWT.decode(jwt_token, secret_key, algorithm)[0]
+      claims = JWT.decode(jwt_token, secret_key)[0]
       unless verified_request?(request: request, claims: claims)
         raise RequestVerificationFailedError, "Request failed verification"
       end

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "1.0.2".freeze
+  VERSION = "1.1.0".freeze
 end

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -265,6 +265,17 @@ RSpec.describe JWTSignedRequest do
         end
       end
 
+      context 'and expiry leeway is not provided' do
+        subject(:verify_request) do
+          described_class.verify(request: request, secret_key: secret_key)
+        end
+
+        it 'does not pass the leeway with options' do
+          verify_request
+          expect(JWT).to have_received(:decode).with(jwt_token, secret_key, true, {})
+        end
+      end
+
       it 'allows the body to be read' do
         verify_request
         expect(request.body.read).to eq 'data=body'

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe JWTSignedRequest do
 
         it 'uses the specified leeway' do
           verify_request
-          expect(JWT).to have_received(:decode).with(jwt_token, secret_key, true, {leeway:123})
+          expect(JWT).to have_received(:decode).with(jwt_token, secret_key, true, leeway: 123)
         end
       end
 

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -254,14 +254,14 @@ RSpec.describe JWTSignedRequest do
         end
       end
 
-      context 'and the algorithm is explicit' do
+      context 'and expiry leeway is provided' do
         subject(:verify_request) do
-          described_class.verify(request: request, secret_key: secret_key, algorithm: 'HS256')
+          described_class.verify(request: request, secret_key: secret_key, leeway: 123)
         end
 
-        it 'uses the specified algorithm' do
+        it 'uses the specified leeway' do
           verify_request
-          expect(JWT).to have_received(:decode).with(jwt_token, secret_key, 'HS256')
+          expect(JWT).to have_received(:decode).with(jwt_token, secret_key, true, {leeway:123})
         end
       end
 


### PR DESCRIPTION
Due to clock skew between systems we wish to communicate between, I need to add a leeway to particular request verifications.

This PR also removes the (incorrect) passing of an `algorithm` param to the `JWT.verify` call

TODO:

- [x]  bump version
- [x]  add note to README
- [ ] publish new gem version