### PR TITLE
Omit exp claim

### DIFF
--- a/lib/jwt_signed_request/claims.rb
+++ b/lib/jwt_signed_request/claims.rb
@@ -30,14 +30,14 @@ module JWTSignedRequest
         headers: serialized_headers,
         body_sha: body_sha,
       }
-      result[:exp] = (Time.now + timeout).to_i if @include_exp
+      result[:exp] = (Time.now + timeout).to_i if include_exp
       result[:iss] = issuer if issuer
       result
     end
 
     private
 
-    attr_reader :method, :path, :headers, :body, :additional_headers_to_sign, :timeout, :issuer
+    attr_reader :method, :path, :headers, :body, :additional_headers_to_sign, :timeout, :issuer, :include_exp
 
     HEADERS_TO_SIGN = %w(
       Content-Type

--- a/lib/jwt_signed_request/claims.rb
+++ b/lib/jwt_signed_request/claims.rb
@@ -18,6 +18,7 @@ module JWTSignedRequest
       @additional_headers_to_sign = additional_headers_to_sign
       @timeout = timeout
       @issuer = issuer
+      @include_exp = false # TODO: allow this to be configured
     end
 
     private_class_method :new
@@ -28,8 +29,8 @@ module JWTSignedRequest
         path: path,
         headers: serialized_headers,
         body_sha: body_sha,
-        exp: (Time.now + timeout).to_i
       }
+      result[:exp] = (Time.now + timeout).to_i if @include_exp
       result[:iss] = issuer if issuer
       result
     end

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "1.2.0".freeze
+  VERSION = "1.3.1".freeze
 end

--- a/spec/jwt_signed_request/claims_spec.rb
+++ b/spec/jwt_signed_request/claims_spec.rb
@@ -59,11 +59,10 @@ RSpec.describe JWTSignedRequest::Claims do
       expect(valid_json?(headers)).to eq(true)
     end
 
-    it 'includes an expiration time claim 30 seconds from now' do
+    it 'does not include an expiration time claim' do
       request_time = Time.parse("2016-06-02T13:20:30Z")
-      expiry_time = Time.parse("2016-06-02T13:21:00Z")
       Timecop.freeze(request_time) do
-        expect(claims).to include(exp: 1464873660)
+        expect(claims.keys).to_not include(:exp)
       end
     end
 


### PR DESCRIPTION
Communicating from one system to another where the clocks are out can lead to problems with the  tokens expiring.

This patch removes the 'exp' (expiry) claim from all signed tokens.

TODO:

- [ ] add the ability to configure this so it is "opt-in"