### PR TITLE
Ability to specify paths to exclude from request verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
 class Server < Sinatra::Base
   use JWTSignedRequest::Middlewares::Rack,
      secret_key: OpenSSL::PKey::EC.new(PUBLIC_KEY),
-     exclude_paths: /health/              #optional
+     exclude_paths: /public|health/              # optional regex
  end
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
 
 class Server < Sinatra::Base
   use JWTSignedRequest::Middlewares::Rack,
-     secret_key: OpenSSL::PKey::EC.new(PUBLIC_KEY)
+     secret_key: OpenSSL::PKey::EC.new(PUBLIC_KEY),
+     exclude_paths: /health/              #optional
  end
 ```
 

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "1.2.0".freeze
+  VERSION = "1.2.1".freeze
 end

--- a/spec/jwt_signed_request/middlewares/rack_spec.rb
+++ b/spec/jwt_signed_request/middlewares/rack_spec.rb
@@ -30,4 +30,40 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
       expect(code).to eq(200)
     end
   end
+
+  context 'when exclude_paths options is defined' do
+    let :middleware do
+      JWTSignedRequest::Middlewares::Rack.new(app, secret_key: 'secret', exclude_paths: /api|health/)
+    end
+
+    before do
+      allow(JWTSignedRequest).to receive(:verify)
+    end
+
+    context 'and request path is not excluded' do
+      let(:env) do
+        {
+          'REQUEST_PATH' => '/verify'
+        }
+      end
+
+      it 'verifies the request' do
+        code, header, body = verify_request
+        expect(JWTSignedRequest).to have_received(:verify)
+      end
+    end
+
+    context 'and request path is excluded' do
+      let(:env) do
+        {
+          'REQUEST_PATH' => '/health'
+        }
+      end
+
+      it 'does not verify the request' do
+        code, header, body = verify_request
+        expect(JWTSignedRequest).not_to have_received(:verify)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds the ability to specify the paths to exclude from request
verification for rack middlewares.

Usage

```ruby
class Server < Sinatra::Base
  use JWTSignedRequest::Middlewares::Rack,
     secret_key: OpenSSL::PKey::EC.new(PUBLIC_KEY),
     exclude_paths: /public|health/              #optional regex
 end
```