### PR TITLE
Minor fixes

### DIFF
--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -60,7 +60,7 @@ module JWTSignedRequest
   end
 
   def self.verified_request?(request:, claims:)
-    claims['method'].downcase == request.request_method.downcase &&
+    claims['method'].to_s.downcase == request.request_method.downcase &&
       claims['path'] == request.fullpath &&
       claims['body_sha'] == Digest::SHA256.hexdigest(request_body(request: request)) &&
       verified_headers?(request: request, claims: claims)

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -77,7 +77,11 @@ module JWTSignedRequest
   private_class_method :request_body
 
   def self.verified_headers?(request:, claims:)
-    parsed_headers = JSON.parse(claims['headers'])
+    parsed_headers = begin
+      JSON.parse(claims['headers'])
+    rescue JSON::ParserError
+      {}
+    end
 
     parsed_headers.all? do |header_key, header_value|
       Headers.fetch(header_key, request) == header_value

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -78,7 +78,7 @@ module JWTSignedRequest
 
   def self.verified_headers?(request:, claims:)
     parsed_headers = begin
-      JSON.parse(claims['headers'])
+      JSON.parse(claims['headers'].to_s)
     rescue JSON::ParserError
       {}
     end

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -262,6 +262,14 @@ RSpec.describe JWTSignedRequest do
         end
       end
 
+      context 'and there are no headers in the claims' do
+        let(:headers) { nil }
+
+        it 'does not raise an error' do
+          expect { verify_request }.to_not raise_error
+        end
+      end
+
       context 'and expiry leeway is provided' do
         subject(:verify_request) do
           described_class.verify(request: request, secret_key: secret_key, leeway: 123)

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -230,6 +230,14 @@ RSpec.describe JWTSignedRequest do
         end
       end
 
+      context 'and there is no request method in the claims' do
+        let(:method) { nil }
+
+        it 'raises a RequestVerificationFailedError' do
+          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
+        end
+      end
+
       context 'and the request path is different' do
         let(:path) { '/api/different/endpoint'}
 

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe JWTSignedRequest do
         end
       end
 
-      context 'and the request headers is different' do
+      context 'and the request headers are different' do
         let(:headers) { { 'content-type' => 'application/xml' } }
 
         it 'raises a RequestVerificationFailedError' do

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe JWTSignedRequest do
     let(:path) { request_env['REQUEST_PATH'] }
     let(:body) { request_env['rack.input'] }
     let(:body_sha) { Digest::SHA256.hexdigest(body.string) }
-    let(:headers) { { 'content-type' => 'application/json' } }
+    let(:headers) { JSON.dump('content-type' => 'application/json') }
 
     subject(:verify_request) do
       described_class.verify(request: request, secret_key: secret_key)
@@ -208,7 +208,7 @@ RSpec.describe JWTSignedRequest do
           'method' => method,
           'path' => path,
           'body_sha' => body_sha,
-          'headers' => JSON.dump(headers)
+          'headers' => headers,
         }]
       end
 
@@ -255,7 +255,7 @@ RSpec.describe JWTSignedRequest do
       end
 
       context 'and the request headers are different' do
-        let(:headers) { { 'content-type' => 'application/xml' } }
+        let(:headers) { JSON.dump('content-type' => 'application/xml') }
 
         it 'raises a RequestVerificationFailedError' do
           expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
@@ -264,6 +264,14 @@ RSpec.describe JWTSignedRequest do
 
       context 'and there are no headers in the claims' do
         let(:headers) { nil }
+
+        it 'does not raise an error' do
+          expect { verify_request }.to_not raise_error
+        end
+      end
+
+      context 'and the headers are invalid JSON in the claim' do
+        let(:headers) { 'invalid' }
 
         it 'does not raise an error' do
           expect { verify_request }.to_not raise_error


### PR DESCRIPTION
We saw some standard Ruby errors coming from this gem when doing some testing with invalid keys.

    NoMethodError: undefined method `downcase' for nil:NilClass`

Fixed this with a `to_s`.

    TypeError: no implicit conversion of nil into String

Fixed this with a `to_s` and rescue parsing invalid JSON.