### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v1.2.2] - 2017-05-11
 ### Changed
 - Fix minor claims releated errors from @twe4ked.
+
+## [v2.0.0] - 2015-06-21
+### Changed
+- Added ability to add signing and verifying keys to the `KeyStore`
+- Changed API so users can instead provide a `key_id` when signing requests
+- With requestes signed with a `key_id`, there is no need to provide a `secret_key` when verifying requests.
+- Backwards compability with version 1.x.x

--- a/VERSION_1.md
+++ b/VERSION_1.md
@@ -1,0 +1,139 @@
+# Using Version 1.X.X
+
+Below is the documentation on how to use the gem for version 1.x.x
+
+Please note that we are only supporting this functionaility for next first few releases of version 2.x.x
+Look (over for details of new API)[https://github.com/envato/jwt_signed_request/blob/master/README.md].
+
+## Signing Requests
+
+If you are using an asymmetrical encryption algorithm such as ES256 you will sign your requests using the private key.
+
+### Using net/http
+
+```ruby
+require 'net/http'
+require 'uri'
+require 'openssl'
+require 'jwt_signed_request'
+
+private_key = """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+-----END EC PRIVATE KEY-----
+"""
+
+uri = URI('http://example.com')
+req = Net::HTTP::Get.new(uri)
+
+req['Authorization'] = JWTSignedRequest.sign(
+  method: req.method,
+  path: req.path,
+  headers: {"Content-Type" => "application/json"},
+  body: "",
+  secret_key: OpenSSL::PKey::EC.new(private_key),
+  algorithm: 'ES256',                     # optional (default: ES256)
+  key_id: 'my-key-id',                    # optional
+  issuer: 'my-issuer'                     # optional
+  additional_headers_to_sign: ['X-AUTH']  # optional
+)
+
+res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+  http.request(req)
+}
+```
+
+### Using faraday
+
+```ruby
+require 'faraday'
+require 'openssl'
+require 'jwt_signed_request/middlewares/faraday'
+
+private_key = """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+-----END EC PRIVATE KEY-----
+"""
+
+conn = Faraday.new(url: URI.parse('http://example.com')) do |faraday|
+  faraday.use JWTSignedRequest::Middlewares::Faraday,
+    secret_key: OpenSSL::PKey::EC.new(private_key),
+    algorithm: 'ES256',                     # optional (default: ES256)
+    key_id: 'my-key-id',                    # optional
+    issuer: 'my-issuer',                    # optional
+    additional_headers_to_sign: ['X-AUTH']  # optional
+
+  faraday.adapter Faraday.default_adapter
+end
+
+conn.post do |req|
+  req.url 'http://example.com'
+  req.body = '{ "name": "Unagi" }'
+end
+```
+
+## Verifying Requests
+
+If you are using an asymmetrical encryption algorithm such as ES256 you will verify the request using the public key.
+
+## Using Rails
+
+```ruby
+class APIController < ApplicationController
+  PUBLIC_KEY = """
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/O
+exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+-----END PUBLIC KEY-----
+  """
+
+  before_action :verify_request
+
+  ...
+
+  private
+
+  def verify_request
+    begin
+      JWTSignedRequest.verify(
+        request: request,
+        secret_key: OpenSSL::PKey::EC.new(PUBLIC_KEY)
+      )
+
+    rescue JWTSignedRequest::UnauthorizedRequestError => e
+      render :json => {}, :status => :unauthorized
+    end
+  end
+
+end
+```
+
+### Increasing Expiry leeway
+
+JWT tokens contain an expiry timestamp. If communication delays are large (or system clocks are sufficiently out of synch), you may need to increase the 'leeway' when verifying. For example:
+
+```ruby
+  JWTSignedRequest.verify(request: request, secret_key: 'my_public_key', leeway: 55)
+```
+
+## Using Rack Middleware
+
+```ruby
+PUBLIC_KEY = """
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/O
+exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+-----END PUBLIC KEY-----
+"""
+
+class Server < Sinatra::Base
+  use JWTSignedRequest::Middlewares::Rack,
+     secret_key: OpenSSL::PKey::EC.new(PUBLIC_KEY),
+     exclude_paths: /public|health/              # optional regex
+ end
+```

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -1,8 +1,11 @@
 require 'jwt'
+require 'jwt_signed_request/key_store'
 require 'jwt_signed_request/sign'
 require 'jwt_signed_request/verify'
 
 module JWTSignedRequest
+  extend self
+
   DEFAULT_ALGORITHM = 'ES256'.freeze
   EMPTY_BODY = "".freeze
 
@@ -10,12 +13,23 @@ module JWTSignedRequest
   MissingAuthorizationHeaderError = Class.new(UnauthorizedRequestError)
   JWTDecodeError = Class.new(UnauthorizedRequestError)
   RequestVerificationFailedError = Class.new(UnauthorizedRequestError)
+  MissingKeyIdError = Class.new(UnauthorizedRequestError)
+  UnknownKeyIdError = Class.new(UnauthorizedRequestError)
+  AlgorithmMismatchError = Class.new(UnauthorizedRequestError)
 
-  def self.sign(*args)
+  def configure_keys
+    yield(key_store)
+  end
+
+  def key_store
+    @key_store ||= KeyStore.new
+  end
+
+  def sign(*args)
     Sign.call(*args)
   end
 
-  def self.verify(*args)
+  def verify(*args)
     Verify.call(*args)
   end
 end

--- a/lib/jwt_signed_request/key_store.rb
+++ b/lib/jwt_signed_request/key_store.rb
@@ -1,0 +1,32 @@
+module JWTSignedRequest
+  class KeyStore
+    def initialize
+      @signing_keys = {}
+      @verification_keys = {}
+    end
+
+    def add_signing_key(key_id:, key:, algorithm:)
+      @signing_keys.store(key_id,
+        {
+          key: key,
+          algorithm: algorithm
+        })
+    end
+
+    def add_verification_key(key_id:, key:, algorithm:)
+      @verification_keys.store(key_id,
+        {
+          key: key,
+          algorithm: algorithm
+        })
+    end
+
+    def get_signing_key(key_id:)
+      @signing_keys.fetch(key_id, {})
+    end
+
+    def get_verification_key(key_id:)
+      @verification_keys.fetch(key_id, {})
+    end
+  end
+end

--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -15,7 +15,6 @@ module JWTSignedRequest
           path:       env[:url].request_uri,
           headers:    env[:request_headers],
           body:       env.fetch(:body, ::JWTSignedRequest::EMPTY_BODY),
-          secret_key: options[:secret_key],
           **optional_settings
         )
 
@@ -29,6 +28,7 @@ module JWTSignedRequest
 
       def optional_settings
         {
+          secret_key:                 options[:secret_key],
           algorithm:                  options[:algorithm],
           additional_headers_to_sign: options[:additional_headers_to_sign],
           key_id:                     options[:key_id],

--- a/lib/jwt_signed_request/middlewares/rack.rb
+++ b/lib/jwt_signed_request/middlewares/rack.rb
@@ -8,7 +8,7 @@ module JWTSignedRequest
 
       def initialize(app, options = {})
         @app = app
-        @secret_key = options.fetch(:secret_key)
+        @secret_key = options[:secret_key]
         @algorithm = options[:algorithm]
         @exclude_paths = options[:exclude_paths]
       end
@@ -16,11 +16,13 @@ module JWTSignedRequest
       def call(env)
         begin
           unless excluded_path?(env)
-            ::JWTSignedRequest.verify(
+            args = {
               request: ::Rack::Request.new(env),
               secret_key: secret_key,
               algorithm: algorithm
-            )
+            }.reject { |_, value| value.nil? }
+
+            ::JWTSignedRequest.verify(**args)
           end
 
           app.call(env)

--- a/lib/jwt_signed_request/sign.rb
+++ b/lib/jwt_signed_request/sign.rb
@@ -11,8 +11,8 @@ module JWTSignedRequest
       path:,
       body: EMPTY_BODY,
       headers:,
-      secret_key:,
-      algorithm: DEFAULT_ALGORITHM,
+      secret_key: nil,
+      algorithm: nil,
       key_id: nil,
       issuer: nil,
       additional_headers_to_sign: nil
@@ -35,8 +35,20 @@ module JWTSignedRequest
     private
 
     attr_reader \
-      :method, :path, :body, :headers, :secret_key, :algorithm,
+      :method, :path, :body, :headers,
       :key_id, :issuer, :additional_headers_to_sign
+
+    def stored_key
+      @stored_key ||= JWTSignedRequest.key_store.get_signing_key(key_id: key_id)
+    end
+
+    def secret_key
+      @secret_key ||= stored_key.fetch(:key) { raise MissingKeyIdError }
+    end
+
+    def algorithm
+      @algorithm ||= stored_key.fetch(:algorithm, DEFAULT_ALGORITHM)
+    end
 
     def additional_jwt_headers
       key_id ? {kid: key_id} : {}

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "1.2.2".freeze
+  VERSION = "2.0.0".freeze
 end

--- a/spec/jwt_signed_request_backwards_compatible_integration_spec.rb
+++ b/spec/jwt_signed_request_backwards_compatible_integration_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Integration test" do
     end
   end
 
-  context 'when request is un-signed' do
+  context 'when request is unsigned' do
     it 'receives an unauthorized status code' do
       get '/'
       expect(last_response.status).to eq(401)
@@ -71,8 +71,8 @@ RSpec.describe "Integration test" do
       pem
     end
 
-    it 'request is signed and verfied successfully' do
-      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+    it 'request is signed and verified successfully' do
+      body = {"first_name" => "Bob", "last_name" => "Hawke"}
 
       jwt_token = JWTSignedRequest.sign(
         method: 'POST',
@@ -88,7 +88,7 @@ RSpec.describe "Integration test" do
     end
 
     context 'with query parameters in the path' do
-      it 'request is signed and verfied successfully' do
+      it 'request is signed and verified successfully' do
         jwt_token = JWTSignedRequest.sign(
           method: 'GET',
           path: '/?foo=bar&baz=quz',

--- a/spec/jwt_signed_request_backwards_compatible_integration_spec.rb
+++ b/spec/jwt_signed_request_backwards_compatible_integration_spec.rb
@@ -1,0 +1,106 @@
+ENV['RACK_ENV'] = 'test'
+require 'rack/test'
+require 'jwt_signed_request/middlewares/rack'
+require 'jwt_signed_request'
+
+RSpec.describe "Integration test" do
+  include Rack::Test::Methods
+
+  let(:algorithm) { 'ES256' }
+
+  def app
+    public_key = <<-pem.gsub(/^\s+/, "")
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/O
+      exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+      -----END PUBLIC KEY-----
+    pem
+
+    Rack::Builder.new do
+      use JWTSignedRequest::Middlewares::Rack,
+        secret_key: OpenSSL::PKey::EC.new(public_key),
+        algorithm: 'ES256'
+
+      map "/" do
+        run Proc.new {|env| [200, {'Content-Type' => 'application/json'}, []] }
+      end
+    end
+  end
+
+  context 'when request is un-signed' do
+    it 'receives an unauthorized status code' do
+      get '/'
+      expect(last_response.status).to eq(401)
+    end
+  end
+
+  context 'when request is signed with a different private key' do
+    let(:private_key) do
+      <<-pem.gsub(/^\s+/, "")
+        -----BEGIN EC PRIVATE KEY-----
+        MHcCAQEEIO4uHlYp5qN6bMJTpwrkXVZkLNMLDrgay5wJGJvE/dCwoAoGCCqGSM49
+        AwEHoUQDQgAEUUDX/9UmvQH1312oPBVjrmF0DzfCcLVVsGFAmyPgHiQuM+lj/I4w
+        hPUBUQdavy12vg6VqMra1Hps7acm5ZcZ0A==
+        -----END EC PRIVATE KEY-----
+      pem
+    end
+
+    it 'receives an unauthorized status code' do
+      jwt_token = JWTSignedRequest.sign(
+        method: 'GET',
+        path: '/',
+        body: '',
+        headers: {'Content-Type' => 'application/json'},
+        secret_key: OpenSSL::PKey::EC.new(private_key),
+        algorithm: 'ES256'
+      )
+
+      get '/', '', { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      expect(last_response.status).to eq(401)
+    end
+  end
+
+  context 'when request is signed with the correct private key' do
+    let(:private_key) do
+      <<-pem.gsub(/^\s+/, "")
+        -----BEGIN EC PRIVATE KEY-----
+        MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+        AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+        3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+        -----END EC PRIVATE KEY-----
+      pem
+    end
+
+    it 'request is signed and verfied successfully' do
+      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+
+      jwt_token = JWTSignedRequest.sign(
+        method: 'POST',
+        path: '/',
+        body: body,
+        headers: {'Content-Type' => 'application/json'},
+        secret_key: OpenSSL::PKey::EC.new(private_key),
+        algorithm: 'ES256'
+      )
+
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      expect(last_response.status).to eq(200)
+    end
+
+    context 'with query parameters in the path' do
+      it 'request is signed and verfied successfully' do
+        jwt_token = JWTSignedRequest.sign(
+          method: 'GET',
+          path: '/?foo=bar&baz=quz',
+          body: '',
+          headers: {'Content-Type' => 'application/json'},
+          secret_key: OpenSSL::PKey::EC.new(private_key),
+          algorithm: 'ES256'
+        )
+
+        get '/?foo=bar&baz=quz', nil, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -5,10 +5,17 @@ require 'jwt_signed_request'
 
 RSpec.describe "Integration test" do
   include Rack::Test::Methods
+  let(:key_id) { 'client_a' }
 
-  let(:algorithm) { 'ES256' }
+  before(:all) do
+    private_key = <<-pem.gsub(/^\s+/, "")
+        -----BEGIN EC PRIVATE KEY-----
+        MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+        AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+        3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+        -----END EC PRIVATE KEY-----
+      pem
 
-  def app
     public_key = <<-pem.gsub(/^\s+/, "")
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/O
@@ -16,11 +23,24 @@ RSpec.describe "Integration test" do
       -----END PUBLIC KEY-----
     pem
 
-    Rack::Builder.new do
-      use JWTSignedRequest::Middlewares::Rack,
-        secret_key: OpenSSL::PKey::EC.new(public_key),
-        algorithm: 'ES256'
+    JWTSignedRequest.configure_keys do |config|
+      config.add_signing_key(
+        key_id: 'client_a',
+        key: OpenSSL::PKey::EC.new(private_key),
+        algorithm: 'ES256',
+      )
 
+      config.add_verification_key(
+        key_id: 'client_a',
+        key: OpenSSL::PKey::EC.new(public_key),
+        algorithm: 'ES256',
+      )
+    end
+  end
+
+  def app
+    Rack::Builder.new do
+      use JWTSignedRequest::Middlewares::Rack
       map "/" do
         run Proc.new {|env| [200, {'Content-Type' => 'application/json'}, []] }
       end
@@ -28,48 +48,91 @@ RSpec.describe "Integration test" do
   end
 
   context 'when request is un-signed' do
-    it 'receives an unauthorized status code' do
+    it 'returns an unauthorized status code' do
       get '/'
       expect(last_response.status).to eq(401)
     end
   end
 
-  context 'when request is signed with a different private key' do
-    let(:private_key) do
-      <<-pem.gsub(/^\s+/, "")
+  context 'when request is signed with an unknown key id' do
+    let(:key_id) { 'unknown' }
+
+    it 'returns an unauthorized status code' do
+      incorrect_private_key = <<-pem.gsub(/^\s+/, "")
         -----BEGIN EC PRIVATE KEY-----
         MHcCAQEEIO4uHlYp5qN6bMJTpwrkXVZkLNMLDrgay5wJGJvE/dCwoAoGCCqGSM49
         AwEHoUQDQgAEUUDX/9UmvQH1312oPBVjrmF0DzfCcLVVsGFAmyPgHiQuM+lj/I4w
         hPUBUQdavy12vg6VqMra1Hps7acm5ZcZ0A==
         -----END EC PRIVATE KEY-----
       pem
-    end
 
-    it 'receives an unauthorized status code' do
+      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+
       jwt_token = JWTSignedRequest.sign(
-        method: 'GET',
+        method: 'POST',
         path: '/',
-        body: '',
+        body: body,
         headers: {'Content-Type' => 'application/json'},
-        secret_key: OpenSSL::PKey::EC.new(private_key),
-        algorithm: 'ES256'
+        key_id: key_id,
+        secret_key: OpenSSL::PKey::EC.new(incorrect_private_key),
       )
 
-      get '/', '', { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
       expect(last_response.status).to eq(401)
     end
   end
 
-  context 'when request is signed with the correct private key' do
-    let(:private_key) do
-      <<-pem.gsub(/^\s+/, "")
+  context 'when signed with the wrong key' do
+    let(:key_id) { 'client_a' }
+
+    it 'returns an unauthorized status code' do
+      incorrect_private_key = <<-pem.gsub(/^\s+/, "")
         -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
-        AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
-        3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+        MHcCAQEEIO4uHlYp5qN6bMJTpwrkXVZkLNMLDrgay5wJGJvE/dCwoAoGCCqGSM49
+        AwEHoUQDQgAEUUDX/9UmvQH1312oPBVjrmF0DzfCcLVVsGFAmyPgHiQuM+lj/I4w
+        hPUBUQdavy12vg6VqMra1Hps7acm5ZcZ0A==
         -----END EC PRIVATE KEY-----
       pem
+
+      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+
+      jwt_token = JWTSignedRequest.sign(
+        method: 'POST',
+        path: '/',
+        body: body,
+        headers: {'Content-Type' => 'application/json'},
+        key_id: key_id,
+        secret_key: OpenSSL::PKey::EC.new(incorrect_private_key),
+      )
+
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      expect(last_response.status).to eq(401)
     end
+  end
+
+  context 'when signed with an incorrect algorithm' do
+    let(:key_id) { 'client_a' }
+
+    it 'returns an unauthorized status code' do
+      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+
+      jwt_token = JWTSignedRequest.sign(
+        method: 'POST',
+        path: '/',
+        body: body,
+        headers: {'Content-Type' => 'application/json'},
+        key_id: key_id,
+        secret_key: "secret",
+        algorithm: 'HS512'
+      )
+
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      expect(last_response.status).to eq(401)
+    end
+  end
+
+  context 'when request is signed with the correct key_id' do
+    let(:key_id) { 'client_a' }
 
     it 'request is signed and verfied successfully' do
       body = {"first_name" => "Bob", "last_name" => "Hawk"}
@@ -79,28 +142,11 @@ RSpec.describe "Integration test" do
         path: '/',
         body: body,
         headers: {'Content-Type' => 'application/json'},
-        secret_key: OpenSSL::PKey::EC.new(private_key),
-        algorithm: 'ES256'
+        key_id: key_id,
       )
 
       post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
       expect(last_response.status).to eq(200)
-    end
-
-    context 'with query parameters in the path' do
-      it 'request is signed and verfied successfully' do
-        jwt_token = JWTSignedRequest.sign(
-          method: 'GET',
-          path: '/?foo=bar&baz=quz',
-          body: '',
-          headers: {'Content-Type' => 'application/json'},
-          secret_key: OpenSSL::PKey::EC.new(private_key),
-          algorithm: 'ES256'
-        )
-
-        get '/?foo=bar&baz=quz', nil, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
-        expect(last_response.status).to eq(200)
-      end
     end
   end
 end

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Integration test" do
     end
   end
 
-  context 'when request is un-signed' do
+  context 'when request is unsigned' do
     it 'returns an unauthorized status code' do
       get '/'
       expect(last_response.status).to eq(401)
@@ -134,8 +134,8 @@ RSpec.describe "Integration test" do
   context 'when request is signed with the correct key_id' do
     let(:key_id) { 'client_a' }
 
-    it 'request is signed and verfied successfully' do
-      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+    it 'request is signed and verified successfully' do
+      body = {"first_name" => "Bob", "last_name" => "Hawke"}
 
       jwt_token = JWTSignedRequest.sign(
         method: 'POST',


### PR DESCRIPTION
Currently we can only have one key pair for an endpoint we want to do
request signing and verification. This is an issue as we need to share
the same signing key to all our clients.

We need a new way to allow a verification server to be able to verify
different signing keys used by clients.

In Version 2.0.0 we have have introduced a concept of a `KeyStore` where
you can add signing and verification keys to.

For example when signing requests:

```ruby
private_key = <<-pem.gsub(/^\s+/, "")
    -----BEGIN EC PRIVATE KEY-----
    MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
    AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
    3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
    -----END EC PRIVATE KEY-----
  pem

require 'openssl'

JWTSignedRequest.configure_keys do |config|
  config.add_signing_key(
    key_id: 'client_a',
    key: OpenSSL::PKey::EC.new(private_key),
    algorithm: 'ES256',
  )
end

jwt_token = JWTSignedRequest.sign(
  method: 'GET',
  path: '/api',
  headers: {"Content-Type" => "application/json"},
  body: "",
  key_id: 'client_a',
)
```

Now when signing requests we only have to specify the key_id we are
using.

When verifying requests:

```ruby
public_key = <<-pem.gsub(/^\s+/, "")
  -----BEGIN PUBLIC KEY-----
  MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/O
  exDdlmXEjHYaixzYIduluGXd3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
  -----END PUBLIC KEY-----
pem

require 'openssl'

JWTSignedRequest.configure_keys do |config|
  config.add_verification_key(
    key_id: 'client_a',
    key: OpenSSL::PKey::EC.new(public_key),
    algorithm: 'ES256',
  )
end

JWTSignedRequest.verify(request: request)
```

Now when verifying requests we are getting the key_id that was used to sign the JWT
token. This key_id is used to find the corresponding verification key
from the key store.

Note: We have made this backwards compatible with the older versions of the gem but would look to remove that functionality in the future as we get users to upgrade.