### PR TITLE
Test `PATH_INFO` instead of `REQUEST_PATH` for path exclusion

### DIFF
--- a/lib/jwt_signed_request/middlewares/rack.rb
+++ b/lib/jwt_signed_request/middlewares/rack.rb
@@ -37,7 +37,7 @@ module JWTSignedRequest
 
       def excluded_path?(env)
         !exclude_paths.nil? &&
-          env['REQUEST_PATH'].match(exclude_paths)
+          env['PATH_INFO'].match(exclude_paths)
       end
     end
   end

--- a/spec/jwt_signed_request/middlewares/rack_spec.rb
+++ b/spec/jwt_signed_request/middlewares/rack_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
     context 'and request path is not excluded' do
       let(:env) do
         {
-          'REQUEST_PATH' => '/verify'
+          'PATH_INFO' => '/verify'
         }
       end
 
@@ -56,7 +56,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
     context 'and request path is excluded' do
       let(:env) do
         {
-          'REQUEST_PATH' => '/health'
+          'PATH_INFO' => '/health'
         }
       end
 

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -14,7 +14,6 @@ module JWTSignedRequest
         "rack.multiprocess"=>false,
         "rack.run_once"=>false,
         "REQUEST_METHOD"=>"POST",
-        "REQUEST_PATH"=>"/api/endpoint",
         "PATH_INFO"=>"/api/endpoint",
         "REQUEST_URI"=>"/api/endpoint",
         "CONTENT_TYPE"=>"application/json",
@@ -43,7 +42,7 @@ module JWTSignedRequest
     let(:jwt_token) { 'potato' }
 
     let(:method) { request_env['REQUEST_METHOD'] }
-    let(:path) { request_env['REQUEST_PATH'] }
+    let(:path) { request_env['PATH_INFO'] }
     let(:body) { request_env['rack.input'] }
     let(:body_sha) { Digest::SHA256.hexdigest(body.string) }
     let(:headers) { JSON.dump('content-type' => 'application/json') }


### PR DESCRIPTION
## Context

fixes #15 - it appears that in some cases `REQUEST_PATH` is not provided, whereas `PATH_INFO` is [required to be present](http://www.rubydoc.info/github/rack/rack/file/SPEC)

## Changes

- `s/REQUEST_PATH/PATH_INFO`

