### PR TITLE
Lock JWT dependency to 1.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.1.0] - 2017-08-31
 ### Changed
 - Check `PATH_INFO` instead of `REQUEST_PATH` when performing path exclusion
+
+## [v2.1.1] - 2017-09-14
+### Changed
+- Pin `jwt` gem dependency to version `1.5.x`, as the recent 2.0.0 release is currently incompatible with `jwt_signed_request`

--- a/jwt_signed_request.gemspec
+++ b/jwt_signed_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jwt'
+  spec.add_dependency 'jwt', '~> 1.5.0'
   spec.add_dependency 'rack'
 
   spec.add_development_dependency "bundler"

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "2.1.0".freeze
+  VERSION = "2.1.1".freeze
 end


### PR DESCRIPTION
It looks like version 2 of the `jwt` gem, which has recently been released, is incompatible with `jwt_signed_request` as it currently stands (`undefined method 'decoded_segments' for JWT:Module`). This means that if you're installing `jwt_signed_request` now into a new project and bundler brings down v2 of the `jwt` gem, it won't work at all.

I haven't yet had a chance to dig in and see about adding v2 support, so for now figured we should pin the `jwt` dependency to 1.5.x.