### PR TITLE
Pass ownership to rubygems@envato.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,4 +30,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.1.2] - 2017-09-15
 ### Changed
 - Pass ownership to rubygems@envato.com
-- Add contributers to README
+- Add contributors to README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.1.1] - 2017-09-14
 ### Changed
 - Pin `jwt` gem dependency to version `1.5.x`, as the recent 2.0.0 release is currently incompatible with `jwt_signed_request`
+
+## [v2.1.2] - 2017-09-15
+### Changed
+- Pass ownership to rubygems@envato.com
+- Add contributers to README

--- a/README.md
+++ b/README.md
@@ -181,16 +181,16 @@ details.
 We welcome contribution from everyone. Read more about it in
 [`CODE_OF_CONDUCT.md`](https://github.com/envato/jwt_signed_request/blob/master/CODE_OF_CONDUCT.md)
 
-## Contributers
+## Contributors
 
-Many thanks to the following contributers to this gem:
+Many thanks to the following contributors to this gem:
 
 - Toan Nguyen - [@yoshdog](https://github.com/yoshdog)
 - Odin Dutton - [@twe4ked](https://github.com/twe4ked)
 - Sebastian von Conrad - [@vonconrad](https://github.com/vonconrad)
 - Zubin Henner- [@zubin](https://github.com/zubin)
 - Glen Tweedie - [@nocache](https://github.com/nocache)
-- Giancarlo Salamanca - [@giancarlo](https://github.com/giancarlo)
+- Giancarlo Salamanca - [@salamagd](https://github.com/salamagd)
 - Ben Axnick - [@bentheax](https://github.com/bentheax)
 - Glen Stampoultzis - [@gstamp](https://github.com/gstamp)
 - Lucas Parry - [@lparry](https://github.com/lparry)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Please note that the way we sign and verify requests has changed in version 2.x.
 We are only supporting the old API for the next couple of releases of version 2.x.x so please upgrade ASAP.
 
 ## Maintainers
-- [Toan Nguyen](https://github.com/yoshdog)
+- [Envato](https://github.com/envato)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ details.
 We welcome contribution from everyone. Read more about it in
 [`CODE_OF_CONDUCT.md`](https://github.com/envato/jwt_signed_request/blob/master/CODE_OF_CONDUCT.md)
 
+## Contributers
+
+Many thanks to the following contributers to this gem:
+
+- Toan Nguyen - [@yoshdog](https://github.com/yoshdog)
+- Odin Dutton - [@twe4ked](https://github.com/twe4ked)
+- Sebastian von Conrad - [@vonconrad](https://github.com/vonconrad)
+- Zubin Henner- [@zubin](https://github.com/zubin)
+- Glen Tweedie - [@nocache](https://github.com/nocache)
+- Giancarlo Salamanca - [@giancarlo](https://github.com/giancarlo)
+- Ben Axnick - [@bentheax](https://github.com/bentheax)
+- Glen Stampoultzis - [@gstamp](https://github.com/gstamp)
+- Lucas Parry - [@lparry](https://github.com/lparry)
+
 ## Contributing
 
 For bug fixes, documentation changes, and small features:

--- a/jwt_signed_request.gemspec
+++ b/jwt_signed_request.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |spec|
   spec.name          = "jwt_signed_request"
   spec.version       = JWTSignedRequest::VERSION
 
-  spec.authors       = ["Toan Nguyen"]
-  spec.email         = ["toan.nguyen@envato.com"]
+  spec.authors       = ["Envato"]
+  spec.email         = ["rubygems@envato.com"]
 
   spec.summary       = %q{JWT request signing and verification for Internal APIs}
   spec.description   = %q{}

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "2.1.1".freeze
+  VERSION = "2.1.2".freeze
 end


### PR DESCRIPTION
This will allow other developers at envato to maintain the gem.
You should be able to push new versions of the gem using the rubygems@envato.com account.

Added contributors section on the readme to give thanks to the many
lovely contributors.