### PR TITLE
Support alternate lookup key ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ req['Authorization'] = JWTSignedRequest.sign(
   headers: {"Content-Type" => "application/json"},
   body: "",
   key_id: 'my-key-id',                    # used for looking up key and kid header
-  target_key_id: 'my-alt-key-id',         # optionally override kid header value
+  lookup_key_id: 'my-alt-key-id',         # optionally override lookup key
   issuer: 'my-issuer'                     # optional
   additional_headers_to_sign: ['X-AUTH']  # optional
 )

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ req['Authorization'] = JWTSignedRequest.sign(
   path: req.path,
   headers: {"Content-Type" => "application/json"},
   body: "",
-  key_id: 'my-key-id',
+  key_id: 'my-key-id',                    # used for looking up key and kid header
+  target_key_id: 'my-alt-key-id',         # optionally override kid header value
   issuer: 'my-issuer'                     # optional
   additional_headers_to_sign: ['X-AUTH']  # optional
 )

--- a/lib/jwt_signed_request/sign.rb
+++ b/lib/jwt_signed_request/sign.rb
@@ -14,7 +14,7 @@ module JWTSignedRequest
       secret_key: nil,
       algorithm: nil,
       key_id: nil,
-      target_key_id: key_id,
+      lookup_key_id: key_id,
       issuer: nil,
       additional_headers_to_sign: nil
     )
@@ -25,7 +25,7 @@ module JWTSignedRequest
       @secret_key = secret_key
       @algorithm = algorithm
       @key_id = key_id
-      @target_key_id = target_key_id
+      @lookup_key_id = lookup_key_id
       @issuer = issuer
       @additional_headers_to_sign = additional_headers_to_sign
     end
@@ -38,10 +38,10 @@ module JWTSignedRequest
 
     attr_reader \
       :method, :path, :body, :headers,
-      :key_id, :target_key_id, :issuer, :additional_headers_to_sign
+      :key_id, :lookup_key_id, :issuer, :additional_headers_to_sign
 
     def stored_key
-      @stored_key ||= JWTSignedRequest.key_store.get_signing_key(key_id: key_id)
+      @stored_key ||= JWTSignedRequest.key_store.get_signing_key(key_id: lookup_key_id)
     end
 
     def secret_key
@@ -53,7 +53,7 @@ module JWTSignedRequest
     end
 
     def additional_jwt_headers
-      target_key_id ? {kid: target_key_id} : {}
+      key_id ? {kid: key_id} : {}
     end
 
     def claims

--- a/lib/jwt_signed_request/sign.rb
+++ b/lib/jwt_signed_request/sign.rb
@@ -14,6 +14,7 @@ module JWTSignedRequest
       secret_key: nil,
       algorithm: nil,
       key_id: nil,
+      target_key_id: key_id,
       issuer: nil,
       additional_headers_to_sign: nil
     )
@@ -24,6 +25,7 @@ module JWTSignedRequest
       @secret_key = secret_key
       @algorithm = algorithm
       @key_id = key_id
+      @target_key_id = target_key_id
       @issuer = issuer
       @additional_headers_to_sign = additional_headers_to_sign
     end
@@ -36,7 +38,7 @@ module JWTSignedRequest
 
     attr_reader \
       :method, :path, :body, :headers,
-      :key_id, :issuer, :additional_headers_to_sign
+      :key_id, :target_key_id, :issuer, :additional_headers_to_sign
 
     def stored_key
       @stored_key ||= JWTSignedRequest.key_store.get_signing_key(key_id: key_id)
@@ -51,7 +53,7 @@ module JWTSignedRequest
     end
 
     def additional_jwt_headers
-      key_id ? {kid: key_id} : {}
+      target_key_id ? {kid: target_key_id} : {}
     end
 
     def claims

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -5,6 +5,7 @@ require 'jwt_signed_request'
 
 RSpec.describe "Integration test" do
   include Rack::Test::Methods
+
   let(:key_id) { 'client_a' }
 
   before(:all) do

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Integration test" do
         -----END EC PRIVATE KEY-----
       pem
 
-      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+      body = {"first_name" => "Bob", "last_name" => "Hawke"}
 
       jwt_token = JWTSignedRequest.sign(
         method: 'POST',
@@ -95,7 +95,7 @@ RSpec.describe "Integration test" do
         -----END EC PRIVATE KEY-----
       pem
 
-      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+      body = {"first_name" => "Bob", "last_name" => "Hawke"}
 
       jwt_token = JWTSignedRequest.sign(
         method: 'POST',
@@ -115,7 +115,7 @@ RSpec.describe "Integration test" do
     let(:key_id) { 'client_a' }
 
     it 'returns an unauthorized status code' do
-      body = {"first_name" => "Bob", "last_name" => "Hawk"}
+      body = {"first_name" => "Bob", "last_name" => "Hawke"}
 
       jwt_token = JWTSignedRequest.sign(
         method: 'POST',

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Integration test" do
     end
   end
 
-  context 'with target_key_id specified' do
+  context 'with lookup_key_id specified' do
     before do
       private_key = <<-pem.gsub(/^\s+/, "")
         -----BEGIN EC PRIVATE KEY-----
@@ -178,8 +178,8 @@ RSpec.describe "Integration test" do
         path: '/',
         body: body,
         headers: {'Content-Type' => 'application/json'},
-        key_id: 'server_a',
-        target_key_id: 'client_a',
+        key_id: 'client_a',
+        lookup_key_id: 'server_a',
       )
       sent_key_id = ::JWT.decoded_segments(jwt_token, false).first.fetch('kid')
 

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe "Integration test" do
 
   before(:all) do
     private_key = <<-pem.gsub(/^\s+/, "")
-        -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
-        AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
-        3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
-        -----END EC PRIVATE KEY-----
-      pem
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+      AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+      3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+      -----END EC PRIVATE KEY-----
+    pem
 
     public_key = <<-pem.gsub(/^\s+/, "")
       -----BEGIN PUBLIC KEY-----

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe "Integration test" do
     let(:key_id) { 'unknown' }
 
     it 'returns an unauthorized status code' do
-      incorrect_private_key = <<-pem.gsub(/^\s+/, "")
+      correct_private_key = <<-pem.gsub(/^\s+/, "")
         -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIO4uHlYp5qN6bMJTpwrkXVZkLNMLDrgay5wJGJvE/dCwoAoGCCqGSM49
-        AwEHoUQDQgAEUUDX/9UmvQH1312oPBVjrmF0DzfCcLVVsGFAmyPgHiQuM+lj/I4w
-        hPUBUQdavy12vg6VqMra1Hps7acm5ZcZ0A==
+        MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+        AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+        3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
         -----END EC PRIVATE KEY-----
       pem
 
@@ -75,7 +75,7 @@ RSpec.describe "Integration test" do
         body: body,
         headers: {'Content-Type' => 'application/json'},
         key_id: key_id,
-        secret_key: OpenSSL::PKey::EC.new(incorrect_private_key),
+        secret_key: OpenSSL::PKey::EC.new(correct_private_key),
       )
 
       post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }


### PR DESCRIPTION
Context
--

Currently, `JWTSignedRequest.configure_keys` assumes that both client and server reference the same key ID.

That is, the `key_id` argument is used for fetching the configured key and also for the JWT header's `kid` value.

Sometimes clients and servers want to use different key IDs.

Change
--

Add an optional `lookup_key_id` argument to `JWTSignedRequest.sign` which is solely used for looking up a configured key from the key store (when omitted, `key_id` is used).