### PR TITLE
Bump to v2.1.3

### DIFF
--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "2.1.2".freeze
+  VERSION = "2.1.3".freeze
 end


### PR DESCRIPTION
This version adds an optional `lookup_key_id` arg to `JWTSignedRequest.sign`.