### PR TITLE
When testing equivalence of paths, ensure queries are sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Many thanks to the following contributors to this gem:
 - Odin Dutton - [@twe4ked](https://github.com/twe4ked)
 - Sebastian von Conrad - [@vonconrad](https://github.com/vonconrad)
 - Zubin Henner- [@zubin](https://github.com/zubin)
-- Glen Tweedie - [@nocache](https://github.com/nocache)
+- Glenn Tweedie - [@nocache](https://github.com/nocache)
 - Giancarlo Salamanca - [@salamagd](https://github.com/salamagd)
 - Ben Axnick - [@bentheax](https://github.com/bentheax)
 - Glen Stampoultzis - [@gstamp](https://github.com/gstamp)

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -107,11 +107,11 @@ module JWTSignedRequest
     end
 
     def claims_query_values
-      standard_query_values parsed_claims_path
+      standard_query_values(parsed_claims_path)
     end
 
     def request_query_values
-      standard_query_values URI.parse(request.fullpath)
+      standard_query_values(URI.parse(request.fullpath))
     end
   end
 end

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -70,7 +70,7 @@ module JWTSignedRequest
 
     def verified_request?
       claims['method'].to_s.downcase == request.request_method.downcase &&
-        parsed_claims_path.path == request.path &&
+        parsed_claims_uri.path == request.path &&
         verified_query_strings? &&
         claims['body_sha'] == Digest::SHA256.hexdigest(request_body) &&
         verified_headers?
@@ -94,8 +94,8 @@ module JWTSignedRequest
       end
     end
 
-    def parsed_claims_path
-      @parsed_claims_path ||= URI.parse(claims['path'])
+    def parsed_claims_uri
+      @parsed_claims_uri ||= URI.parse(claims['path'])
     end
 
     def standard_query_values(path)
@@ -107,7 +107,7 @@ module JWTSignedRequest
     end
 
     def claims_query_values
-      standard_query_values(parsed_claims_path)
+      standard_query_values(parsed_claims_uri)
     end
 
     def request_query_values

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -105,6 +105,15 @@ module JWTSignedRequest
         end
       end
 
+      context 'and the request query params are in a different order' do
+        before { request_env['QUERY_STRING'] = 'c=3&b=2&a=1' }
+        let(:path) { '/api/endpoint?a=1&b=2&c=3'}
+
+        it 'does not raise any errors' do
+          expect{ verify_request }.not_to raise_error
+        end
+      end
+
       context 'and the body is different' do
         let(:body_sha) { '1ddfd12592f1090bb0f18a744abe97d07c7adacad3d3a27a9bfa927ff07f7b3c' }
 


### PR DESCRIPTION
we were having issues authenticating between 2 systems
because the order of the query string parts in the JWT claim was different 
to the order that Rack was presenting.

This ensures they are both sorted before testing them