### PR TITLE
Raise specific error classes for each verification (type) failure

### DIFF
--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -2,20 +2,13 @@ require 'jwt'
 require 'jwt_signed_request/key_store'
 require 'jwt_signed_request/sign'
 require 'jwt_signed_request/verify'
+require 'jwt_signed_request/errors'
 
 module JWTSignedRequest
   extend self
 
   DEFAULT_ALGORITHM = 'ES256'.freeze
   EMPTY_BODY = "".freeze
-
-  UnauthorizedRequestError = Class.new(StandardError)
-  MissingAuthorizationHeaderError = Class.new(UnauthorizedRequestError)
-  JWTDecodeError = Class.new(UnauthorizedRequestError)
-  RequestVerificationFailedError = Class.new(UnauthorizedRequestError)
-  MissingKeyIdError = Class.new(UnauthorizedRequestError)
-  UnknownKeyIdError = Class.new(UnauthorizedRequestError)
-  AlgorithmMismatchError = Class.new(UnauthorizedRequestError)
 
   def configure_keys
     yield(key_store)

--- a/lib/jwt_signed_request/errors.rb
+++ b/lib/jwt_signed_request/errors.rb
@@ -2,10 +2,14 @@ module JWTSignedRequest
   UnauthorizedRequestError = Class.new(StandardError)
   MissingAuthorizationHeaderError = Class.new(UnauthorizedRequestError)
   JWTDecodeError = Class.new(UnauthorizedRequestError)
+
   RequestVerificationFailedError = Class.new(UnauthorizedRequestError)
-  %w[Method Path Header Body Query].each do |type|
-    module_eval("Request#{type}VerificationFailedError = Class.new(RequestVerificationFailedError)")
-  end
+  RequestBodyVerificationFailedError = Class.new(RequestVerificationFailedError)
+  RequestHeaderVerificationFailedError = Class.new(RequestVerificationFailedError)
+  RequestMethodVerificationFailedError = Class.new(RequestVerificationFailedError)
+  RequestPathVerificationFailedError = Class.new(RequestVerificationFailedError)
+  RequestQueryVerificationFailedError = Class.new(RequestVerificationFailedError)
+
   MissingKeyIdError = Class.new(UnauthorizedRequestError)
   UnknownKeyIdError = Class.new(UnauthorizedRequestError)
   AlgorithmMismatchError = Class.new(UnauthorizedRequestError)

--- a/lib/jwt_signed_request/errors.rb
+++ b/lib/jwt_signed_request/errors.rb
@@ -1,0 +1,12 @@
+module JWTSignedRequest
+  UnauthorizedRequestError = Class.new(StandardError)
+  MissingAuthorizationHeaderError = Class.new(UnauthorizedRequestError)
+  JWTDecodeError = Class.new(UnauthorizedRequestError)
+  RequestVerificationFailedError = Class.new(UnauthorizedRequestError)
+  %w[Method Path Header Body Query].each do |type|
+    module_eval("Request#{type}VerificationFailedError = Class.new(RequestVerificationFailedError)")
+  end
+  MissingKeyIdError = Class.new(UnauthorizedRequestError)
+  UnknownKeyIdError = Class.new(UnauthorizedRequestError)
+  AlgorithmMismatchError = Class.new(UnauthorizedRequestError)
+end

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -69,19 +69,25 @@ module JWTSignedRequest
 
     def verify_request!
       unless request.request_method.casecmp(claims['method'].to_s) == 0
-        raise RequestMethodVerificationFailedError, "Request failed method verification"
+        raise RequestMethodVerificationFailedError,
+          "Request failed method verification.\nexpected:#{claims['method']}\nreceived:#{request.request_method}"
       end
       unless parsed_claims_uri.path == request.path
-        raise RequestPathVerificationFailedError, "Request failed path verification"
+        raise RequestPathVerificationFailedError,
+          "Request failed path verification.\nexpected:#{parsed_claims_uri.path}\nreceived:#{request.path}"
       end
-      unless verified_query_strings?
-        raise RequestQueryVerificationFailedError, "Request failed query string verification"
+      unless claims_query_values == request_query_values
+        raise RequestQueryVerificationFailedError,
+          "Request failed query string verification.\nexpected:#{claims_query_values}\nreceived:#{request_query_values}"
       end
       unless claims['body_sha'] == Digest::SHA256.hexdigest(request_body)
-        raise RequestBodyVerificationFailedError, "Request failed body verification"
+        raise RequestBodyVerificationFailedError,
+          "Request failed body verification.\nexpected:#{claims['body_sha']}\
+          received:#{Digest::SHA256.hexdigest(request_body)}"
       end
       unless verified_headers?
-        raise RequestHeaderVerificationFailedError, "Request failed header verification"
+        raise RequestHeaderVerificationFailedError,
+          "Request failed header verification.\nexpected:#{claims['headers']}"
       end
     end
 
@@ -109,10 +115,6 @@ module JWTSignedRequest
 
     def standard_query_values(path)
       URI.decode_www_form(path.query).sort if path && path.query
-    end
-
-    def verified_query_strings?
-      claims_query_values == request_query_values
     end
 
     def claims_query_values

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -84,24 +84,24 @@ module JWTSignedRequest
       context 'and the request method is different' do
         let(:method) { 'GET' }
 
-        it 'raises a RequestVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
+        it 'raises a RequestMethodVerificationFailedError' do
+          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
         end
       end
 
       context 'and there is no request method in the claims' do
         let(:method) { nil }
 
-        it 'raises a RequestVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
+        it 'raises a RequestMethodVerificationFailedError' do
+          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
         end
       end
 
       context 'and the request path is different' do
         let(:path) { '/api/different/endpoint'}
 
-        it 'raises a RequestVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
+        it 'raises a RequestPathVerificationFailedError' do
+          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestPathVerificationFailedError)
         end
       end
 
@@ -117,16 +117,16 @@ module JWTSignedRequest
       context 'and the body is different' do
         let(:body_sha) { '1ddfd12592f1090bb0f18a744abe97d07c7adacad3d3a27a9bfa927ff07f7b3c' }
 
-        it 'raises a RequestVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
+        it 'raises a RequestBodyVerificationFailedError' do
+          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestBodyVerificationFailedError)
         end
       end
 
       context 'and the request headers are different' do
         let(:headers) { JSON.dump('content-type' => 'application/xml') }
 
-        it 'raises a RequestVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestVerificationFailedError)
+        it 'raises a RequestHeaderVerificationFailedError' do
+          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestHeaderVerificationFailedError)
         end
       end
 


### PR DESCRIPTION
When request verification fails in a running system, it can be very difficult to figure out why.
This PR adds different error subclasses for each type of verification failure.
Systems verifying requests can use these to determine what to do - eg logging the error class will allow quicker diagnosis of errors.