### PR TITLE
Fix changelog order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v1.2.0] - 2017-03-28
+## [v2.2.0] - 2018-04-05
 ### Changed
-- Allow configurable expiry leeway to verification
+- Sort query string parameters before comparing them
+- If request fails verification, raise error that indicates specifically what failed
 
-## [v1.2.2] - 2017-05-11
+## [v2.1.2] - 2017-09-15
 ### Changed
-- Fix minor claims releated errors from @twe4ked.
+- Pass ownership to rubygems@envato.com
+- Add contributors to README
+
+## [v2.1.1] - 2017-09-14
+### Changed
+- Pin `jwt` gem dependency to version `1.5.x`, as the recent 2.0.0 release is currently incompatible with `jwt_signed_request`
+
+## [v2.1.0] - 2017-08-31
+### Changed
+- Check `PATH_INFO` instead of `REQUEST_PATH` when performing path exclusion
 
 ## [v2.0.0] - 2017-06-21
 ### Changed
@@ -19,20 +29,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - With requestes signed with a `key_id`, there is no need to provide a `secret_key` when verifying requests.
 - Backwards compability with version 1.x.x
 
-## [v2.1.0] - 2017-08-31
+## [v1.2.2] - 2017-05-11
 ### Changed
-- Check `PATH_INFO` instead of `REQUEST_PATH` when performing path exclusion
+- Fix minor claims releated errors from @twe4ked.
 
-## [v2.1.1] - 2017-09-14
+## [v1.2.0] - 2017-03-28
 ### Changed
-- Pin `jwt` gem dependency to version `1.5.x`, as the recent 2.0.0 release is currently incompatible with `jwt_signed_request`
-
-## [v2.1.2] - 2017-09-15
-### Changed
-- Pass ownership to rubygems@envato.com
-- Add contributors to README
-
-## [v2.2.0] - 2018-04-05
-### Changed
-- Sort query string parameters before comparing them
-- If request fails verification, raise error that indicates specifically what failed
+- Allow configurable expiry leeway to verification


### PR DESCRIPTION
From: https://keepachangelog.com/en/1.0.0/

> * The latest version comes first.

I read a lot of changelogs every week and this one is upside-down compared to the convention I see most commonly.

I'd appreciate if we flip the order so the the stuff people care about is in front of them as soon as the changelog loads/opens.