### PR TITLE
Use the more stable JWT.decode to extract 'kid'

### DIFF
--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -29,7 +29,7 @@ module JWTSignedRequest
     attr_reader :request, :leeway
 
     def stored_key
-      jwt_header, _, _, _ = ::JWT.decoded_segments(jwt_token, false)
+      _body, jwt_header = ::JWT.decode(jwt_token, nil, false)
       key_id = jwt_header.fetch('kid') { raise MissingKeyIdError }
       signed_algorithm = jwt_header.fetch('alg')
       JWTSignedRequest.key_store.get_verification_key(key_id: key_id).tap do |key|


### PR DESCRIPTION
The API for `JWT.decoded_segments` has been moved around as well as the arguments. Instead we can use `JWT.decode` to get the same result which is the same across different versions of the jwt Gem.

All the tests are still passing against the latest version of the jwt Gem. I've not verified this against all other versions as I don't have apps running but it looks like this part of the API has been stable for a long time.