### PR TITLE
Add support for JWT version 2.1

### DIFF
--- a/jwt_signed_request.gemspec
+++ b/jwt_signed_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jwt', '~> 1.5.0'
+  spec.add_dependency 'jwt', '>= 1.5.0', '< 2.2.0'
   spec.add_dependency 'rack'
 
   spec.add_development_dependency "bundler"

--- a/lib/jwt_signed_request/errors.rb
+++ b/lib/jwt_signed_request/errors.rb
@@ -11,6 +11,7 @@ module JWTSignedRequest
   RequestQueryVerificationFailedError = Class.new(RequestVerificationFailedError)
 
   MissingKeyIdError = Class.new(UnauthorizedRequestError)
+  MissingAlgorithmError = Class.new(UnauthorizedRequestError)
   UnknownKeyIdError = Class.new(UnauthorizedRequestError)
   AlgorithmMismatchError = Class.new(UnauthorizedRequestError)
 end

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -1,5 +1,6 @@
 require 'jwt_signed_request/headers'
 require 'jwt_signed_request/errors'
+require 'jwt/version'
 
 module JWTSignedRequest
   class Verify
@@ -39,6 +40,10 @@ module JWTSignedRequest
       end
     end
 
+    def algorithm
+      @algorithm ||= stored_key.fetch(:algorithm) { raise MissingAlgorithmError }
+    end
+
     def secret_key
       @secret_key ||= stored_key.fetch(:key) { raise MissingKeyIdError }
     end
@@ -51,6 +56,8 @@ module JWTSignedRequest
       @claims ||= begin
         verify = true
         options = {}
+
+        options[:algorithm] = algorithm if jwt_algorithm_required?
 
         if leeway
           # TODO: Once JWT v2.0.0 has been released, we should upgrade to it
@@ -123,6 +130,10 @@ module JWTSignedRequest
 
     def request_query_values
       standard_query_values(URI.parse(request.fullpath))
+    end
+
+    def jwt_algorithm_required?
+      JWT::VERSION::MAJOR >= 2
     end
   end
 end

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -181,7 +181,8 @@ RSpec.describe "Integration test" do
         key_id: 'client_a',
         lookup_key_id: 'server_a',
       )
-      sent_key_id = ::JWT.decoded_segments(jwt_token, false).first.fetch('kid')
+      _body, jwt_header = ::JWT.decode(jwt_token, nil, false)
+      sent_key_id = jwt_header.fetch('kid')
 
       post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
       expect(last_response.status).to eq(200)


### PR DESCRIPTION
Newer versions of JWT require that the signing algorithm must be specified
when verifying a JWT. https://github.com/jwt/ruby-jwt/commit/0a2b94433c4626dae797de68d0f530c3cf6fed9d

When verifying the request we now use the algorithm of the
stored key.

An exception will be raised when using JWT 2.x when attempting to use a
stored key that does not specify an algorithm.

The deprecated argument `algorithm` for the `JWTSignedRequest::Verify.initialize` method was previously redundant and setting it did nothing. This argument if set would effectively override the algorithm for the found stored_key. This however is the same behaviour of the other deprecated argument `secret_key` and seems somewhat consistent.

This seems to be working for me using both versions 1.x and 2.x of the JWT Gem. I've not been able to do any thorough testing but thought I'd share this for any comments/improvements that could be made.

I don't think there is a breaking change here so it could be nice to get this released without a major number change.