### PR TITLE
Add leeway as a configuration option for the rack middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.4.0] - 2018-07-24
+### Changed
+- Added ability to configure verification leeway via the rack middleware
+
 ## [v2.3.0] - 2018-06-15
-## Changed
+### Changed
 - Use `JWT.decode` to extract the `kid` a JWT token.
 
 ## [v2.2.0] - 2018-04-05

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ JWT tokens contain an expiry timestamp. If communication delays are large (or sy
 ```ruby
 class Server < Sinatra::Base
   use JWTSignedRequest::Middlewares::Rack,
-     exclude_paths: /public|health/              # optional regex
+     exclude_paths: /public|health/,          # optional regex
+     leeway: 100                              # optional
  end
 ```
 

--- a/lib/jwt_signed_request/middlewares/rack.rb
+++ b/lib/jwt_signed_request/middlewares/rack.rb
@@ -10,6 +10,7 @@ module JWTSignedRequest
         @app = app
         @secret_key = options[:secret_key]
         @algorithm = options[:algorithm]
+        @leeway = options[:leeway]
         @exclude_paths = options[:exclude_paths]
       end
 
@@ -19,7 +20,8 @@ module JWTSignedRequest
             args = {
               request: ::Rack::Request.new(env),
               secret_key: secret_key,
-              algorithm: algorithm
+              algorithm: algorithm,
+              leeway: leeway
             }.reject { |_, value| value.nil? }
 
             ::JWTSignedRequest.verify(**args)
@@ -33,7 +35,7 @@ module JWTSignedRequest
 
       private
 
-      attr_reader :app, :secret_key, :algorithm, :exclude_paths
+      attr_reader :app, :secret_key, :algorithm, :leeway, :exclude_paths
 
       def excluded_path?(env)
         !exclude_paths.nil? &&

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,3 +1,3 @@
 module JWTSignedRequest
-  VERSION = "2.3.0".freeze
+  VERSION = "2.4.0".freeze
 end


### PR DESCRIPTION
We have the ability to set a leeway value for verifications, however it is not currently an accepted option for the rack middleware to pass down.