### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.bundle
 pkg/
 Gemfile.lock

--- a/jwt_signed_request.gemspec
+++ b/jwt_signed_request.gemspec
@@ -13,6 +13,12 @@ Gem::Specification.new do |spec|
   spec.description   = %q{}
   spec.homepage      = "https://github.com/envato/jwt_signed_request"
 
+  spec.metadata      = {
+                         'bug_tracker_uri'   => 'https://github.com/envato/jwt_signed_request/issues',
+                         'changelog_uri'     => 'https://github.com/envato/jwt_signed_request/blob/master/CHANGELOG.md',
+                         'source_code_uri'   => 'https://github.com/envato/jwt_signed_request',
+                       }
+
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues, and analyse the changelog. These links will appear on the rubygems page at https://rubygems.org/gems/jwt_signed_request after the next release.