### PR TITLE
Improve the error message of AlgorithmMismatchError

### DIFF
--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -34,7 +34,8 @@ module JWTSignedRequest
       signed_algorithm = jwt_header.fetch('alg')
       JWTSignedRequest.key_store.get_verification_key(key_id: key_id).tap do |key|
         if signed_algorithm != key[:algorithm]
-          raise AlgorithmMismatchError
+          raise AlgorithmMismatchError, "The request is signed with #{signed_algorithm} "\
+            "while #{key[:algorithm]} is configured on key #{key_id}"
         end
       end
     end


### PR DESCRIPTION
## Context

Currently, no error message is provided when the `AlgorithmMismatchError` is raised.

## Change

Improve the error message by adding the following information.

* The algorithm with which the request was signed.
* The algorithm configured on the key.
* The key ID.