### PR TITLE
Ensure bundler is installed on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ rvm:
   - 2.2.5
   - 2.3.1
 sudo: false
+before_install:
+  - gem install bundler
 script:
   - bundle exec rspec --color --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ rvm:
   - 2.2.5
   - 2.3.1
 sudo: false
-before_install:
-  - gem install bundler
 script:
   - bundle exec rspec --color --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
 sudo: false
 script:
   - bundle exec rspec --color --format documentation


### PR DESCRIPTION
Context
--

On a [recent PR], the CI was [failing] due to bundler not being installed.

A [workaround] was suggested, which installs bundler via Travis CI config.

Change
--

~~Add the [workaround] to Travis CI config.~~

[Bundler no longer supports ruby < 2.3]. Therefore, updating supported rubies to ≥ 2.3. 

[recent PR]: https://github.com/envato/jwt_signed_request/pull/28
[failing]: https://travis-ci.org/envato/jwt_signed_request/jobs/476337484
[workaround]: https://github.com/travis-ci/travis-ci/issues/5578#issuecomment-180445244
[Bundler no longer supports ruby < 2.3]: https://github.com/bundler/bundler/issues/6865#issuecomment-451300072