### PR TITLE
Authorization bearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.5.0] - 2019-01-21
 
 ### Changed
+
 - Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema.
 
 ## [v2.4.1] - 2019-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v2.5.0] - 2019-01-21
 ### Changed
-- Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authoirzation headers without the Bearer schema.
+- Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema.
 
 ## [v2.4.1] - 2019-01-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v2.5.0] - 2019-01-21
+
 ### Changed
 - Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.5.0] - 2019-01-21
+### Changed
+- Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authoirzation headers without the Bearer schema.
+
 ## [v2.4.1] - 2019-01-08
 ### Changed
 - Add support for JWT version 2.1

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ require 'jwt_signed_request'
 
 uri = URI('http://example.com')
 req = Net::HTTP::Get.new(uri)
-
-req['Authorization'] = JWTSignedRequest.sign(
+jwt_token = JWTSignedRequest.sign(
   method: req.method,
   path: req.path,
   headers: {"Content-Type" => "application/json"},
@@ -90,6 +89,8 @@ req['Authorization'] = JWTSignedRequest.sign(
   issuer: 'my-issuer'                     # optional
   additional_headers_to_sign: ['X-AUTH']  # optional
 )
+
+req['Authorization'] = "Bearer #{jwt_token}"
 
 res = Net::HTTP.start(uri.hostname, uri.port) {|http|
   http.request(req)

--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -20,7 +20,7 @@ module JWTSignedRequest
           **optional_settings
         )
 
-        env[:request_headers].store("Authorization", jwt_token)
+        env[:request_headers].store("Authorization", "Bearer #{jwt_token}")
         app.call(env)
       end
 

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -50,7 +50,7 @@ module JWTSignedRequest
       @secret_key ||= stored_key.fetch(:key) { raise MissingKeyIdError }
     end
 
-    JWT_BEARER_REGEX = /\A(Bearer\s)?([^*]+)\z/
+    JWT_BEARER_REGEX = /\A(Bearer\s+)?([^*]+)\z/
 
     def jwt_token
       @jwt_token ||= Headers.fetch('Authorization', request) &&

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -50,12 +50,11 @@ module JWTSignedRequest
       @secret_key ||= stored_key.fetch(:key) { raise MissingKeyIdError }
     end
 
-    JWT_BEARER_REGEX = /^Bearer ([^*]+)$/
+    JWT_BEARER_REGEX = /\A(Bearer\s)?([^*]+)\z/
 
     def jwt_token
-      @jwt_token ||= Headers.fetch('Authorization', request)&.match(JWT_BEARER_REGEX) ?
-        Headers.fetch('Authorization', request)&.match(JWT_BEARER_REGEX)[1] :
-        Headers.fetch('Authorization', request)
+      @jwt_token ||= Headers.fetch('Authorization', request) &&
+        Headers.fetch('Authorization', request).match(JWT_BEARER_REGEX)[2]
     end
 
     def claims

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -50,8 +50,12 @@ module JWTSignedRequest
       @secret_key ||= stored_key.fetch(:key) { raise MissingKeyIdError }
     end
 
+    JWT_BEARER_REGEX = /^Bearer ([^*]+)$/
+
     def jwt_token
-      @jwt_token ||= Headers.fetch('Authorization', request)
+      @jwt_token ||= Headers.fetch('Authorization', request)&.match(JWT_BEARER_REGEX) ?
+        Headers.fetch('Authorization', request)&.match(JWT_BEARER_REGEX)[1] :
+        Headers.fetch('Authorization', request)
     end
 
     def claims

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JWTSignedRequest
-  VERSION = '2.4.1'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/spec/jwt_signed_request/middlewares/faraday_spec.rb
+++ b/spec/jwt_signed_request/middlewares/faraday_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
   describe '#call' do
     it 'sets the jwt token in the Authorization Header' do
       response = middleware.call(env).env
-      expect(response[:request_headers]).to include('Authorization' => jwt_token)
+      expect(response[:request_headers]).to include('Authorization' => "Bearer #{jwt_token}")
     end
 
     context 'with optional settings' do

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -91,7 +91,7 @@ module JWTSignedRequest
         end
       end
 
-      context 'and was signed with a missing authorization bearer token' do
+      context 'and signed without an authorization bearer syntax' do
         let(:request) do
           Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => jwt_token}))
         end

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -63,7 +63,7 @@ module JWTSignedRequest
 
     context 'when there is an Authorization header set' do
       let(:request) do
-        Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => jwt_token}))
+        Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}"}))
       end
 
       let(:claims) do
@@ -86,6 +86,16 @@ module JWTSignedRequest
       end
 
       context 'and the request matches the JWT claims' do
+        it 'does not raise any errors' do
+          expect{ verify_request }.not_to raise_error
+        end
+      end
+
+      context 'and was signed with a missing authorization bearer token' do
+        let(:request) do
+          Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => jwt_token}))
+        end
+
         it 'does not raise any errors' do
           expect{ verify_request }.not_to raise_error
         end

--- a/spec/jwt_signed_request_integration_spec.rb
+++ b/spec/jwt_signed_request_integration_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Integration test" do
         secret_key: OpenSSL::PKey::EC.new(correct_private_key),
       )
 
-      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
       expect(last_response.status).to eq(401)
     end
   end
@@ -108,7 +108,7 @@ RSpec.describe "Integration test" do
         secret_key: OpenSSL::PKey::EC.new(incorrect_private_key),
       )
 
-      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
       expect(last_response.status).to eq(401)
     end
   end
@@ -129,7 +129,7 @@ RSpec.describe "Integration test" do
         algorithm: 'HS512'
       )
 
-      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
       expect(last_response.status).to eq(401)
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe "Integration test" do
         key_id: key_id,
       )
 
-      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
       expect(last_response.status).to eq(200)
     end
   end
@@ -186,7 +186,7 @@ RSpec.describe "Integration test" do
       _body, jwt_header = ::JWT.decode(jwt_token, nil, false)
       sent_key_id = jwt_header.fetch('kid')
 
-      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => jwt_token }
+      post '/', body, { 'CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}" }
       expect(last_response.status).to eq(200)
       expect(sent_key_id).to eq('client_a')
     end


### PR DESCRIPTION
Thanks to @jacobbednarz for pointing this out.

Reading: 
https://auth0.com/learn/json-web-tokens/

it says:

> Whenever the user wants to access a protected route, it should send the JWT, typically in the Authorization header using the Bearer schema. Therefore the content of the header should look like the following.
>
>Authorization: Bearer <token>

So in this PR we are prefixing `Bearer` in front of the jwt token when setting the Authorization header. We also are supporting requests that have not prefixed a `Bearer` in the Authorization header.