### PR TITLE
Configurable Authorization header format in Faraday middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.5.0] - 2019-01-21
 
 ### Changed
+
 - Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema
 
 ### Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.5.1] - 2019-01-29
 
 ### Changed
+
 - Added option `bearer_schema` to the Faraday middleware to allow the caller to specify whether to follow the Bearer schema when setting the JWT token in the Authorization request header (defaults to false)
 
 ## [v2.5.0] - 2019-01-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Added option `bearer_schema` to the Faraday middleware to allow the caller to specify whether to follow the Bearer schema when setting the JWT token in the Authorization request header (defaults to false)
+- Added option `bearer_schema` to the Faraday middleware to allow the caller to specify whether to follow the [Bearer schema](https://auth0.com/docs/jwt#how-do-json-web-tokens-work-) when setting the JWT token in the Authorization request header (defaults to false)
 
 ## [v2.5.0] - 2019-01-21
 
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema
 
-### Breaking changes:
+### Caveats
+
 - Requests signed using version 2.5.0 can only be successfully verified by version 2.5.0. This will be addressed in version 2.5.1. To ensure compatibility it is recommended to skip this version or update the version of your request verifying service prior to the request signing service
 
 ## [v2.4.1] - 2019-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [v2.5.0] - 2019-01-21
 
 ### Changed
+- Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema
 
-- Ensure we use the JWT Token in the Authorization header using the Bearer schema. We will still support Authorization headers without the Bearer schema.
+### Breaking changes:
+- Requests signed using version 2.5.0 can only be successfully verified by version 2.5.0. This will be addressed in version 2.5.1. To ensure compatibility it is recommended to skip this version or update the version of your request verifying service prior to the request signing service
 
 ## [v2.4.1] - 2019-01-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.5.1] - 2019-01-29
+
+### Changed
+- Added option `bearer_schema` to the Faraday middleware to allow the caller to specify whether to follow the Bearer schema when setting the JWT token in the Authorization request header (defaults to false)
+
 ## [v2.5.0] - 2019-01-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,46 +20,66 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Requests signed using version 2.5.0 can only be successfully verified by version 2.5.0. This will be addressed in version 2.5.1. To ensure compatibility it is recommended to skip this version or update the version of your request verifying service prior to the request signing service
 
 ## [v2.4.1] - 2019-01-08
+
 ### Changed
+
 - Add support for JWT version 2.1
 
 ## [v2.4.0] - 2018-07-24
+
 ### Changed
+
 - Added ability to configure verification leeway via the rack middleware
 
 ## [v2.3.0] - 2018-06-15
+
 ### Changed
+
 - Use `JWT.decode` to extract the `kid` a JWT token.
 
 ## [v2.2.0] - 2018-04-05
+
 ### Changed
+
 - Sort query string parameters before comparing them
 - If request fails verification, raise error that indicates specifically what failed
 
 ## [v2.1.2] - 2017-09-15
+
 ### Changed
+
 - Pass ownership to rubygems@envato.com
 - Add contributors to README
 
 ## [v2.1.1] - 2017-09-14
+
 ### Changed
+
 - Pin `jwt` gem dependency to version `1.5.x`, as the recent 2.0.0 release is currently incompatible with `jwt_signed_request`
 
 ## [v2.1.0] - 2017-08-31
+
 ### Changed
+
 - Check `PATH_INFO` instead of `REQUEST_PATH` when performing path exclusion
 
 ## [v2.0.0] - 2017-06-21
+
 ### Changed
+
 - Added ability to add signing and verifying keys to the `KeyStore`
 - Changed API so users can instead provide a `key_id` when signing requests
 - With requestes signed with a `key_id`, there is no need to provide a `secret_key` when verifying requests.
 - Backwards compability with version 1.x.x
 
 ## [v1.2.2] - 2017-05-11
+
 ### Changed
+
 - Fix minor claims releated errors from @twe4ked.
 
 ## [v1.2.0] - 2017-03-28
+
 ### Changed
+
 - Allow configurable expiry leeway to verification

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ end
 
 ##### bearer_schema (boolean)
 
-Determines whether to use the Bearer schema when assigning the JWT token to the `Authorization` request header
+Determines whether to use the [Bearer schema](https://auth0.com/docs/jwt#how-do-json-web-tokens-work-) when assigning the JWT token to the `Authorization` request header
 
 | bearer_schema value | Authorization header value|
 |---------------------|---------------------------|

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ conn = Faraday.new(url: URI.parse('http://example.com')) do |faraday|
   faraday.use JWTSignedRequest::Middlewares::Faraday,
     key_id: 'my-key-id',
     issuer: 'my-issuer',                    # optional
-    additional_headers_to_sign: ['X-AUTH']  # optional
+    additional_headers_to_sign: ['X-AUTH'], # optional
+    bearer_schema: true                     # optional
 
   faraday.adapter Faraday.default_adapter
 end
@@ -118,6 +119,18 @@ conn.post do |req|
   req.body = '{ "name": "Unagi" }'
 end
 ```
+
+#### Additional options
+
+##### bearer_schema (boolean)
+
+Determines whether to use the Bearer schema when assigning the JWT token to the `Authorization` request header
+
+| bearer_schema value | Authorization header value|
+|---------------------|---------------------------|
+| false (default) | `<jwt_token>` |
+| true | `Bearer <jwt_token>` |
+
 
 ## Verifying Requests
 

--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -34,7 +34,7 @@ module JWTSignedRequest
       end
 
       def bearer_schema?
-        !!optional_settings[:bearer_schema]
+        options[:bearer_schema] == true
       end
 
       def optional_settings
@@ -44,7 +44,6 @@ module JWTSignedRequest
           additional_headers_to_sign: options[:additional_headers_to_sign],
           key_id:                     options[:key_id],
           issuer:                     options[:issuer],
-          bearer_schema:              options[:bearer_schema] || false,
         }.reject { |_, value| value.nil? }
       end
     end

--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -12,7 +12,7 @@ module JWTSignedRequest
       end
 
       def call(env)
-        jwt_token = ::JWTSignedRequest.sign(
+        @jwt_token = ::JWTSignedRequest.sign(
           method:     env[:method],
           path:       env[:url].request_uri,
           headers:    env[:request_headers],
@@ -20,13 +20,22 @@ module JWTSignedRequest
           **optional_settings
         )
 
-        env[:request_headers].store("Authorization", "Bearer #{jwt_token}")
+        env[:request_headers].store("Authorization", authorization_header)
+
         app.call(env)
       end
 
       private
 
-      attr_reader :app, :env, :options
+      attr_reader :app, :env, :options, :jwt_token
+
+      def authorization_header
+        bearer_schema? ? "Bearer #{jwt_token}" : jwt_token
+      end
+
+      def bearer_schema?
+        !!optional_settings[:bearer_schema]
+      end
 
       def optional_settings
         {
@@ -35,6 +44,7 @@ module JWTSignedRequest
           additional_headers_to_sign: options[:additional_headers_to_sign],
           key_id:                     options[:key_id],
           issuer:                     options[:issuer],
+          bearer_schema:              options[:bearer_schema] || false,
         }.reject { |_, value| value.nil? }
       end
     end

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JWTSignedRequest
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
 end

--- a/spec/jwt_signed_request/middlewares/faraday_spec.rb
+++ b/spec/jwt_signed_request/middlewares/faraday_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
       it 'signs the request using the additional settings' do
         middleware.call(env).env
         expect(JWTSignedRequest).to have_received(:sign).with(
-          hash_including(key_id: 'my-key-id', issuer: 'my-issuer')
+          hash_including(secret_key: 'secret', key_id: 'my-key-id', issuer: 'my-issuer')
         )
       end
     end

--- a/spec/jwt_signed_request/middlewares/faraday_spec.rb
+++ b/spec/jwt_signed_request/middlewares/faraday_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
     {
       method: 'POST',
       url: double(:request_uri => '/api/endpoint?offset=1&limit=10'),
-      body: "body",
+      body: 'body',
       request_headers: {
         'Content-Type' => 'application/json'
       }
@@ -34,25 +34,36 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
   end
 
   describe '#call' do
-    it 'sets the jwt token in the Authorization Header' do
-      response = middleware.call(env).env
-      expect(response[:request_headers]).to include('Authorization' => "Bearer #{jwt_token}")
+    let(:options) do
+      {
+        secret_key: 'secret',
+        key_id: 'my-key-id',
+        issuer: 'my-issuer'
+      }
     end
 
-    context 'with optional settings' do
+    it 'signs the request using the passed in options' do
+      middleware.call(env).env
+      expect(JWTSignedRequest).to have_received(:sign).with(
+        hash_including(secret_key: 'secret', key_id: 'my-key-id', issuer: 'my-issuer')
+      )
+    end
+
+    it 'sets the jwt token in the Authorization Header' do
+      response = middleware.call(env).env
+      expect(response[:request_headers]).to include('Authorization' => jwt_token)
+    end
+
+    context 'when bearer_schema is requested' do
       let(:options) do
         {
-          secret_key: 'secret',
-          key_id: 'my-key-id',
-          issuer: 'my-issuer'
+          bearer_schema: true
         }
       end
 
-      it 'signs the request using the additional settings' do
-        middleware.call(env).env
-        expect(JWTSignedRequest).to have_received(:sign).with(
-          hash_including(secret_key: 'secret', key_id: 'my-key-id', issuer: 'my-issuer')
-        )
+      it 'sets the jwt token in the Authorization Header with the Bearer schema' do
+        response = middleware.call(env).env
+        expect(response[:request_headers]).to include('Authorization' => "Bearer #{jwt_token}")
       end
     end
   end


### PR DESCRIPTION
#### Context

https://github.com/envato/jwt_signed_request/issues/36

As per the above issue, we needed to address an awkward scenario of a backwards compatibility issue when services are using differing versions of this gem.

TL;DR - Requests signed using 2.5.0 (via faraday middleware) were not verifiable on versions < 2.5.0

#### Change

Took a mixture of recommendations from the issue.

- Updated 2.5.0 changelog to indicate the incompatible versions scenario
- Added configurable option (`bearer_schema`) to the Faraday middleware that determines whether to set the Authorization header using the Bearer schema or not (defaults to false to prevent breaking integrations)
- Document the new option in the readme and changelog

Went with a patch version upgrade as its essentially a fix to the previous release