### PR TITLE
Bugfix for faraday middleware

### DIFF
--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -16,7 +16,7 @@ module JWTSignedRequest
           method:     env[:method],
           path:       env[:url].request_uri,
           headers:    env[:request_headers],
-          body:       env.fetch(:body, ::JWTSignedRequest::EMPTY_BODY),
+          body:       request_body(env),
           **optional_settings
         )
 
@@ -45,6 +45,12 @@ module JWTSignedRequest
           key_id:                     options[:key_id],
           issuer:                     options[:issuer],
         }.reject { |_, value| value.nil? }
+      end
+
+      def request_body(env)
+        return env[:body] unless env[:body].nil?
+
+        env[:body] = ::JWTSignedRequest::EMPTY_BODY
       end
     end
   end


### PR DESCRIPTION
Newer versions of faraday (from 0.16.0) separate requests and response bodies,
meaning that `env[:body]` as such doesn't exist anymore but is a shortcut to
`request_body`or `response_body`. https://github.com/lostisland/faraday/commit/6e3c40f159ef514064d05faabf6c6f261662970b

When doing `env.fetch(:body, ::JWTSignedRequest::EMPTY_BODY)` we replace the
value of the request_body resulting in POST/PUT request with empty bodies,
regardless of them being empty previously or not

This PR proposes a fix that is compatible with faraday  0.15.x and 0.16.x