### PR TITLE
Relax restrictions on jwt dependency

### DIFF
--- a/jwt_signed_request.gemspec
+++ b/jwt_signed_request.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jwt', '>= 1.5.0', '< 2.2.0'
+  spec.add_dependency 'jwt', '>= 1.5.0'
   spec.add_dependency 'rack'
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
JWT 2.2.0 is out and it would be nice to be able to track the latest version.