### PR TITLE
Ensure the request body is not emptied in Faraday v1.0.0

### DIFF
--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -16,7 +16,7 @@ module JWTSignedRequest
           method:     env[:method],
           path:       env[:url].request_uri,
           headers:    env[:request_headers],
-          body:       env.fetch(:body, ::JWTSignedRequest::EMPTY_BODY),
+          body:       env[:body] || (env[:body] = ::JWTSignedRequest::EMPTY_BODY),
           **optional_settings
         )
 

--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -12,11 +12,13 @@ module JWTSignedRequest
       end
 
       def call(env)
+        env[:body] ||= ::JWTSignedRequest::EMPTY_BODY
+
         @jwt_token = ::JWTSignedRequest.sign(
           method:     env[:method],
           path:       env[:url].request_uri,
           headers:    env[:request_headers],
-          body:       env[:body] || (env[:body] = ::JWTSignedRequest::EMPTY_BODY),
+          body:       env[:body],
           **optional_settings
         )
 

--- a/spec/jwt_signed_request/middlewares/faraday_spec.rb
+++ b/spec/jwt_signed_request/middlewares/faraday_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
   end
 
   let(:env) do
-    {
+    Faraday::Env.from(
       method: 'POST',
       url: double(:request_uri => '/api/endpoint?offset=1&limit=10'),
       body: 'body',
       request_headers: {
         'Content-Type' => 'application/json'
       }
-    }
+    )
   end
 
   let(:jwt_token) { SecureRandom.hex }
@@ -52,6 +52,11 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
     it 'sets the jwt token in the Authorization Header' do
       response = middleware.call(env).env
       expect(response[:request_headers]).to include('Authorization' => jwt_token)
+    end
+
+    it 'does not empty request body' do
+      request_env = middleware.call(env).env
+      expect(request_env[:body]).to eq('body')
     end
 
     context 'when bearer_schema is requested' do


### PR DESCRIPTION
## Context

JWT Signed Request's Faraday middleware does not work as expected when the request has a body (e.g. a `POST` request) and Faraway version is `v1.0.0`.

It empties the request body no matter the request body has been set or not.

## Change

Replace the problematic `#fetch` method with `#[]` and `#[]=` to ensure JWT Signed Request works as expected in Faraday `v0.17.3` or `v1.0.0`.

## Considerations

The `Faraday::Env#fetch` method (inherited from `Faraday#Options`) works in a way different from the `Hash#fetch` method. It not only returns the value when the key exists but also **sets the value of the key** (❗️) if a second argument is provided.

https://github.com/lostisland/faraday/blob/099dd45f63ff99bbb343eebf7504a3cf0b10bc63/lib/faraday/options.rb#L76-L88

JWT Signed Request uses this method to obtain the request body or set it to an empty string if it was `nil`.

In Faraday v1.0.0, the `:body` option has been replaced with the new `:request_body` and `:response_body` options. Smarter getter (`#[]`) and setter (`#[]=`) methods are provided. When the argument is `:body`, they access `:request_body` or `:response_body` depending on if `:status` has been set.

https://github.com/lostisland/faraday/pull/847

However, the `#fetch` method remains the same.

A request with a body will have the `:request_body` option set but not the `:body` option. That results in JWT Signed Request think the request body was not provided and sets `:request_body` to an empty string.

Instead of the `#fetch` method, I propose we use the `#[]` and `#[]=` method instead.