### PR TITLE
Fix Ruby 2.7.0 deprecation warnings

### DIFF
--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -20,11 +20,11 @@ module JWTSignedRequest
     @key_store ||= KeyStore.new
   end
 
-  def sign(*args)
-    Sign.call(*args)
+  def sign(**args)
+    Sign.call(**args)
   end
 
-  def verify(*args)
-    Verify.call(*args)
+  def verify(**args)
+    Verify.call(**args)
   end
 end

--- a/lib/jwt_signed_request/sign.rb
+++ b/lib/jwt_signed_request/sign.rb
@@ -4,8 +4,8 @@ require 'jwt_signed_request/claims'
 
 module JWTSignedRequest
   class Sign
-    def self.call(*args)
-      new(*args).call
+    def self.call(**args)
+      new(**args).call
     end
 
     def initialize(

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -6,8 +6,8 @@ require 'jwt/version'
 
 module JWTSignedRequest
   class Verify
-    def self.call(*args)
-      new(*args).call
+    def self.call(**args)
+      new(**args).call
     end
 
     # TODO: secret_key & algorithm is deprecated and will be removed in future.

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -5,17 +5,17 @@ require 'jwt_signed_request'
 RSpec.describe JWTSignedRequest do
   describe '.sign' do
     it 'calls the Sign class' do
-      arguments = double :arguments
+      arguments = { arg: true }
       expect(JWTSignedRequest::Sign).to receive(:call).with(arguments)
-      JWTSignedRequest.sign(arguments)
+      JWTSignedRequest.sign(**arguments)
     end
   end
 
   describe '.verify' do
     it 'calls the Verify class' do
-      arguments = double :arguments
+      arguments = { arg: true }
       expect(JWTSignedRequest::Verify).to receive(:call).with(arguments)
-      JWTSignedRequest.verify(arguments)
+      JWTSignedRequest.verify(**arguments)
     end
   end
 end


### PR DESCRIPTION
Fixes the Ruby 2.7.0 deprecation warning like:
```
/.../jwt_signed_request/lib/jwt_signed_request/sign.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.../jwt_signed_request/lib/jwt_signed_request/sign.rb:11: warning: The called method `initialize' is defined here
```