### PR TITLE
Test against additional rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.10
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 sudo: false
 script:
   - bundle exec rspec --color --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.4.0
-  - 2.5.0
-  - 2.6.0
-  - 2.7.0
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 sudo: false
 script:
   - bundle exec rspec --color --format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.3.0
   - 2.4.0
   - 2.5.0
+  - 2.6.0
+  - 2.7.0
 sudo: false
 script:
   - bundle exec rspec --color --format documentation

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -5,7 +5,7 @@ require 'jwt_signed_request'
 RSpec.describe JWTSignedRequest do
   describe '.sign' do
     it 'calls the Sign class' do
-      arguments = { arg: true }
+      arguments = { arg: double }
       expect(JWTSignedRequest::Sign).to receive(:call).with(arguments)
       JWTSignedRequest.sign(**arguments)
     end
@@ -13,7 +13,7 @@ RSpec.describe JWTSignedRequest do
 
   describe '.verify' do
     it 'calls the Verify class' do
-      arguments = { arg: true }
+      arguments = { arg: double }
       expect(JWTSignedRequest::Verify).to receive(:call).with(arguments)
       JWTSignedRequest.verify(**arguments)
     end


### PR DESCRIPTION
#45 addresses deprecation warnings when running on ruby 2.7.0

These warnings were not visible in the builds as we did not test using that version. Lets test against more recent minor versions.