### PR TITLE
Support multiple key stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.6.0] - 2020-08-05
+
+### Added
+
+- Support for multiple key stores
+
 ## [v2.5.4] - 2020-05-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ conn = Faraday.new(url: URI.parse('http://example.com')) do |faraday|
   faraday.use(
     JWTSignedRequest::Middlewares::Faraday,
       key_id: 'my-key-id',
+      key_store_id: 'my-key-store-id',        # optional
       issuer: 'my-issuer',                    # optional
       additional_headers_to_sign: ['X-AUTH'], # optional
       bearer_schema: true,                    # optional
@@ -217,6 +218,7 @@ class Server < Sinatra::Base
     JWTSignedRequest::Middlewares::Rack,
     exclude_paths: /public|health/,          # optional regex
     leeway: 100,                             # optional
+    key_store_id: 'my-key-store-id',         # optional
   )
  end
 ```

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ res = Net::HTTP.start(uri.hostname, uri.port) {|http|
 }
 ```
 
-### Using faraday
+### Using Faraday
 
 ```ruby
 require 'faraday'
@@ -140,11 +140,13 @@ require 'openssl'
 require 'jwt_signed_request/middlewares/faraday'
 
 conn = Faraday.new(url: URI.parse('http://example.com')) do |faraday|
-  faraday.use JWTSignedRequest::Middlewares::Faraday,
-    key_id: 'my-key-id',
-    issuer: 'my-issuer',                    # optional
-    additional_headers_to_sign: ['X-AUTH'], # optional
-    bearer_schema: true                     # optional
+  faraday.use(
+    JWTSignedRequest::Middlewares::Faraday,
+      key_id: 'my-key-id',
+      issuer: 'my-issuer',                    # optional
+      additional_headers_to_sign: ['X-AUTH'], # optional
+      bearer_schema: true,                    # optional
+    )
 
   faraday.adapter Faraday.default_adapter
 end
@@ -211,9 +213,11 @@ JWT tokens contain an expiry timestamp. If communication delays are large (or sy
 
 ```ruby
 class Server < Sinatra::Base
-  use JWTSignedRequest::Middlewares::Rack,
-     exclude_paths: /public|health/,          # optional regex
-     leeway: 100                              # optional
+  use(
+    JWTSignedRequest::Middlewares::Rack,
+    exclude_paths: /public|health/,          # optional regex
+    leeway: 100,                             # optional
+  )
  end
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jwt_token = JWTSignedRequest.sign(
   body: "",
   key_id: 'my-key-id',                    # used for looking up key and kid header
   lookup_key_id: 'my-alt-key-id',         # optionally override lookup key
-  key_store_id: 'widget_admin',           # optionally specify custom key store ID
+  key_store_id: 'widget_admin',           # optionally specify named key store ID
   issuer: 'my-issuer'                     # optional
   additional_headers_to_sign: ['X-AUTH']  # optional
 )

--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ end
 
 ## Signing Requests
 
-If you have added your signing keys to the key store, you will only need to specify the `key_id` you are signing the requests with.
+If you have added your signing keys to a key store, you will only need to
+specify the `key_id` you are signing the requests with.
+
+If you are using multiple key stores, you will also need to pass the
+appropriate `key_store_id`.
 
 ### Using net/http
 
@@ -116,6 +120,7 @@ jwt_token = JWTSignedRequest.sign(
   body: "",
   key_id: 'my-key-id',                    # used for looking up key and kid header
   lookup_key_id: 'my-alt-key-id',         # optionally override lookup key
+  key_store_id: 'widget_admin',           # optionally specify custom key store ID
   issuer: 'my-issuer'                     # optional
   additional_headers_to_sign: ['X-AUTH']  # optional
 )

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -10,7 +10,7 @@ module JWTSignedRequest
   extend self
 
   DEFAULT_ALGORITHM = 'ES256'
-  EMPTY_BODY = ""
+  EMPTY_BODY = ''
 
   def configure_keys
     yield(key_store)

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -10,14 +10,21 @@ module JWTSignedRequest
   extend self
 
   DEFAULT_ALGORITHM = 'ES256'
+  DEFAULT_KEY_STORE_ID = '__default__'
   EMPTY_BODY = ''
+  private_constant :DEFAULT_KEY_STORE_ID
 
-  def configure_keys
+  def configure_keys(key_store_id = DEFAULT_KEY_STORE_ID)
+    key_store = key_stores[key_store_id]
     yield(key_store)
   end
 
   def key_store
-    @key_store ||= KeyStore.new
+    key_stores[DEFAULT_KEY_STORE_ID]
+  end
+
+  def key_stores
+    @key_stores ||= Hash.new { |result, key| result[key] = KeyStore.new }
   end
 
   def sign(**args)

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -19,12 +19,8 @@ module JWTSignedRequest
     yield(key_store)
   end
 
-  def key_store
-    key_stores[DEFAULT_KEY_STORE_ID]
-  end
-
-  def key_stores
-    @key_stores ||= Hash.new { |result, key| result[key] = KeyStore.new }
+  def key_store(id = DEFAULT_KEY_STORE_ID)
+    key_stores[id]
   end
 
   def sign(**args)
@@ -33,5 +29,11 @@ module JWTSignedRequest
 
   def verify(**args)
     Verify.call(**args)
+  end
+
+  private
+
+  def key_stores
+    @key_stores ||= Hash.new { |result, key| result[key] = KeyStore.new }
   end
 end

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -9,8 +9,8 @@ require 'jwt_signed_request/errors'
 module JWTSignedRequest
   extend self
 
-  DEFAULT_ALGORITHM = 'ES256'.freeze
-  EMPTY_BODY = "".freeze
+  DEFAULT_ALGORITHM = 'ES256'
+  EMPTY_BODY = ""
 
   def configure_keys
     yield(key_store)

--- a/lib/jwt_signed_request.rb
+++ b/lib/jwt_signed_request.rb
@@ -10,17 +10,14 @@ module JWTSignedRequest
   extend self
 
   DEFAULT_ALGORITHM = 'ES256'
-  DEFAULT_KEY_STORE_ID = '__default__'
   EMPTY_BODY = ''
-  private_constant :DEFAULT_KEY_STORE_ID
 
-  def configure_keys(key_store_id = DEFAULT_KEY_STORE_ID)
-    key_store = key_stores[key_store_id]
-    yield(key_store)
+  def configure_keys(key_store_id = nil)
+    yield KeyStore.find(key_store_id)
   end
 
-  def key_store(id = DEFAULT_KEY_STORE_ID)
-    key_stores[id]
+  def key_store(id = nil)
+    KeyStore.find(id)
   end
 
   def sign(**args)
@@ -29,11 +26,5 @@ module JWTSignedRequest
 
   def verify(**args)
     Verify.call(**args)
-  end
-
-  private
-
-  def key_stores
-    @key_stores ||= Hash.new { |result, key| result[key] = KeyStore.new }
   end
 end

--- a/lib/jwt_signed_request/key_store.rb
+++ b/lib/jwt_signed_request/key_store.rb
@@ -3,7 +3,11 @@
 module JWTSignedRequest
   class KeyStore
     def self.find(id)
-      id.nil? ? JWTSignedRequest.key_store : JWTSignedRequest.key_store(id)
+      all[id]
+    end
+
+    private_class_method def self.all
+      @all ||= Hash.new { |result, key| result[key] = KeyStore.new }
     end
 
     def initialize

--- a/lib/jwt_signed_request/key_store.rb
+++ b/lib/jwt_signed_request/key_store.rb
@@ -8,19 +8,19 @@ module JWTSignedRequest
     end
 
     def add_signing_key(key_id:, key:, algorithm:)
-      @signing_keys.store(key_id,
-        {
-          key: key,
-          algorithm: algorithm
-        })
+      @signing_keys.store(
+        key_id,
+        key: key,
+        algorithm: algorithm,
+      )
     end
 
     def add_verification_key(key_id:, key:, algorithm:)
-      @verification_keys.store(key_id,
-        {
-          key: key,
-          algorithm: algorithm
-        })
+      @verification_keys.store(
+        key_id,
+        key: key,
+        algorithm: algorithm,
+      )
     end
 
     def get_signing_key(key_id:)

--- a/lib/jwt_signed_request/key_store.rb
+++ b/lib/jwt_signed_request/key_store.rb
@@ -2,6 +2,10 @@
 
 module JWTSignedRequest
   class KeyStore
+    def self.find(id)
+      id.nil? ? JWTSignedRequest.key_store : JWTSignedRequest.key_store(id)
+    end
+
     def initialize
       @signing_keys = {}
       @verification_keys = {}

--- a/lib/jwt_signed_request/middlewares/rack.rb
+++ b/lib/jwt_signed_request/middlewares/rack.rb
@@ -8,12 +8,13 @@ module JWTSignedRequest
     class Rack
       UNAUTHORIZED_STATUS_CODE = 401
 
-      def initialize(app, secret_key: nil, algorithm: nil, leeway: nil, exclude_paths: nil)
+      def initialize(app, secret_key: nil, algorithm: nil, leeway: nil, exclude_paths: nil, key_store_id: nil)
         @app = app
         @secret_key = secret_key
         @algorithm = algorithm
         @leeway = leeway
         @exclude_paths = exclude_paths
+        @key_store_id = key_store_id
       end
 
       def call(env)
@@ -25,7 +26,7 @@ module JWTSignedRequest
 
       private
 
-      attr_reader :app, :secret_key, :algorithm, :leeway, :exclude_paths
+      attr_reader :app, :secret_key, :algorithm, :leeway, :exclude_paths, :key_store_id
 
       def excluded_path?(env)
         !exclude_paths.nil? &&
@@ -38,6 +39,7 @@ module JWTSignedRequest
           secret_key: secret_key,
           algorithm: algorithm,
           leeway: leeway,
+          key_store_id: key_store_id,
         }
       end
     end

--- a/lib/jwt_signed_request/middlewares/rack.rb
+++ b/lib/jwt_signed_request/middlewares/rack.rb
@@ -8,31 +8,19 @@ module JWTSignedRequest
     class Rack
       UNAUTHORIZED_STATUS_CODE = 401
 
-      def initialize(app, options = {})
+      def initialize(app, secret_key: nil, algorithm: nil, leeway: nil, exclude_paths: nil)
         @app = app
-        @secret_key = options[:secret_key]
-        @algorithm = options[:algorithm]
-        @leeway = options[:leeway]
-        @exclude_paths = options[:exclude_paths]
+        @secret_key = secret_key
+        @algorithm = algorithm
+        @leeway = leeway
+        @exclude_paths = exclude_paths
       end
 
       def call(env)
-        begin
-          unless excluded_path?(env)
-            args = {
-              request: ::Rack::Request.new(env),
-              secret_key: secret_key,
-              algorithm: algorithm,
-              leeway: leeway
-            }.reject { |_, value| value.nil? }
-
-            ::JWTSignedRequest.verify(**args)
-          end
-
-          app.call(env)
-        rescue ::JWTSignedRequest::UnauthorizedRequestError => e
-          [UNAUTHORIZED_STATUS_CODE, {'Content-Type' => 'application/json'} , []]
-        end
+        ::JWTSignedRequest.verify(**verification_args(env)) unless excluded_path?(env)
+        app.call(env)
+      rescue ::JWTSignedRequest::UnauthorizedRequestError
+        [UNAUTHORIZED_STATUS_CODE, {'Content-Type' => 'application/json'}, []]
       end
 
       private
@@ -42,6 +30,15 @@ module JWTSignedRequest
       def excluded_path?(env)
         !exclude_paths.nil? &&
           env['PATH_INFO'].match(exclude_paths)
+      end
+
+      def verification_args(env)
+        {
+          request: ::Rack::Request.new(env),
+          secret_key: secret_key,
+          algorithm: algorithm,
+          leeway: leeway,
+        }
       end
     end
   end

--- a/lib/jwt_signed_request/sign.rb
+++ b/lib/jwt_signed_request/sign.rb
@@ -57,7 +57,7 @@ module JWTSignedRequest
     end
 
     def key_store
-      key_store_id.nil? ? JWTSignedRequest.key_store : JWTSignedRequest.key_store(key_store_id)
+      KeyStore.find(key_store_id)
     end
 
     def secret_key

--- a/lib/jwt_signed_request/sign.rb
+++ b/lib/jwt_signed_request/sign.rb
@@ -18,7 +18,8 @@ module JWTSignedRequest
       key_id: nil,
       lookup_key_id: key_id,
       issuer: nil,
-      additional_headers_to_sign: nil
+      additional_headers_to_sign: nil,
+      key_store_id: nil
     )
       @method = method
       @path = path
@@ -30,6 +31,7 @@ module JWTSignedRequest
       @lookup_key_id = lookup_key_id
       @issuer = issuer
       @additional_headers_to_sign = additional_headers_to_sign
+      @key_store_id = key_store_id
     end
 
     def call
@@ -38,12 +40,24 @@ module JWTSignedRequest
 
     private
 
-    attr_reader \
-      :method, :path, :body, :headers,
-      :key_id, :lookup_key_id, :issuer, :additional_headers_to_sign
+    attr_reader(
+      :method,
+      :path,
+      :body,
+      :headers,
+      :key_id,
+      :lookup_key_id,
+      :issuer,
+      :additional_headers_to_sign,
+      :key_store_id,
+    )
 
     def stored_key
-      @stored_key ||= JWTSignedRequest.key_store.get_signing_key(key_id: lookup_key_id)
+      @stored_key ||= key_store.get_signing_key(key_id: lookup_key_id)
+    end
+
+    def key_store
+      key_store_id.nil? ? JWTSignedRequest.key_store : JWTSignedRequest.key_store(key_store_id)
     end
 
     def secret_key

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -12,12 +12,12 @@ module JWTSignedRequest
 
     # TODO: secret_key & algorithm is deprecated and will be removed in future.
     # For now we will support its functionality
-    def initialize(request:, secret_key: nil, algorithm: nil, leeway: nil, key_store: JWTSignedRequest.key_store)
+    def initialize(request:, secret_key: nil, algorithm: nil, leeway: nil, key_store_id: nil)
       @request = request
       @secret_key = secret_key
       @algorithm = algorithm
       @leeway = leeway
-      @key_store = key_store
+      @key_store_id = key_store_id
     end
 
     def call
@@ -30,7 +30,7 @@ module JWTSignedRequest
 
     private
 
-    attr_reader :request, :leeway, :key_store
+    attr_reader :request, :leeway, :key_store_id
 
     def stored_key
       _body, jwt_header = ::JWT.decode(jwt_token, nil, false)
@@ -41,6 +41,10 @@ module JWTSignedRequest
           raise AlgorithmMismatchError
         end
       end
+    end
+
+    def key_store
+      key_store_id.nil? ? JWTSignedRequest.key_store : JWTSignedRequest.key_store(key_store_id)
     end
 
     def algorithm

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -12,11 +12,12 @@ module JWTSignedRequest
 
     # TODO: secret_key & algorithm is deprecated and will be removed in future.
     # For now we will support its functionaility
-    def initialize(request:, secret_key: nil, algorithm: nil, leeway: nil)
+    def initialize(request:, secret_key: nil, algorithm: nil, leeway: nil, key_store: JWTSignedRequest.key_store)
       @request = request
       @secret_key = secret_key
       @algorithm = algorithm
       @leeway = leeway
+      @key_store = key_store
     end
 
     def call
@@ -29,13 +30,13 @@ module JWTSignedRequest
 
     private
 
-    attr_reader :request, :leeway
+    attr_reader :request, :leeway, :key_store
 
     def stored_key
       _body, jwt_header = ::JWT.decode(jwt_token, nil, false)
       key_id = jwt_header.fetch('kid') { raise MissingKeyIdError }
       signed_algorithm = jwt_header.fetch('alg')
-      JWTSignedRequest.key_store.get_verification_key(key_id: key_id).tap do |key|
+      key_store.get_verification_key(key_id: key_id).tap do |key|
         if signed_algorithm != key[:algorithm]
           raise AlgorithmMismatchError
         end

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -44,7 +44,7 @@ module JWTSignedRequest
     end
 
     def key_store
-      key_store_id.nil? ? JWTSignedRequest.key_store : JWTSignedRequest.key_store(key_store_id)
+      KeyStore.find(key_store_id)
     end
 
     def algorithm

--- a/lib/jwt_signed_request/verify.rb
+++ b/lib/jwt_signed_request/verify.rb
@@ -11,7 +11,7 @@ module JWTSignedRequest
     end
 
     # TODO: secret_key & algorithm is deprecated and will be removed in future.
-    # For now we will support its functionaility
+    # For now we will support its functionality
     def initialize(request:, secret_key: nil, algorithm: nil, leeway: nil, key_store: JWTSignedRequest.key_store)
       @request = request
       @secret_key = secret_key

--- a/lib/jwt_signed_request/version.rb
+++ b/lib/jwt_signed_request/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JWTSignedRequest
-  VERSION = '2.5.4'
+  VERSION = '2.6.0'
 end

--- a/spec/jwt_signed_request/middlewares/faraday_spec.rb
+++ b/spec/jwt_signed_request/middlewares/faraday_spec.rb
@@ -38,15 +38,22 @@ RSpec.describe JWTSignedRequest::Middlewares::Faraday do
       {
         secret_key: 'secret',
         key_id: 'my-key-id',
-        issuer: 'my-issuer'
+        issuer: 'my-issuer',
+        key_store_id: 'my-key-store-id',
       }
     end
 
     it 'signs the request using the passed in options' do
       middleware.call(env).env
-      expect(JWTSignedRequest).to have_received(:sign).with(
-        hash_including(secret_key: 'secret', key_id: 'my-key-id', issuer: 'my-issuer')
-      )
+      expect(JWTSignedRequest).to have_received(:sign)
+        .with(
+          hash_including(
+            secret_key: 'secret',
+            key_id: 'my-key-id',
+            issuer: 'my-issuer',
+            key_store_id: 'my-key-store-id',
+          ),
+        )
     end
 
     it 'sets the jwt token in the Authorization Header' do

--- a/spec/jwt_signed_request/middlewares/rack_spec.rb
+++ b/spec/jwt_signed_request/middlewares/rack_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
     end
   end
 
+  context 'with named key store' do
+    let(:middleware) { JWTSignedRequest::Middlewares::Rack.new(app, key_store_id: 'my_key_store_id') }
+
+    it 'passes key store ID option' do
+      expect(JWTSignedRequest).to receive(:verify) do |args|
+        expect(args[:key_store_id]).to eq('my_key_store_id')
+      end
+      verify_request
+    end
+  end
+
   context 'when exclude_paths options is defined' do
     let :middleware do
       JWTSignedRequest::Middlewares::Rack.new(app, secret_key: 'secret', exclude_paths: /api|health/)

--- a/spec/jwt_signed_request/middlewares/rack_spec.rb
+++ b/spec/jwt_signed_request/middlewares/rack_spec.rb
@@ -4,10 +4,8 @@ require 'jwt_signed_request/middlewares/rack'
 
 RSpec.describe JWTSignedRequest::Middlewares::Rack do
   let(:app) { ->(env) { [200, env, "app"] } }
-  let :middleware do
-    JWTSignedRequest::Middlewares::Rack.new(app, secret_key: 'secret')
-  end
-  let(:env) { Hash.new }
+  let(:middleware) { JWTSignedRequest::Middlewares::Rack.new(app, secret_key: 'secret') }
+  let(:env) { {} }
 
   subject(:verify_request) { middleware.call(env) }
 
@@ -17,7 +15,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
     end
 
     it 'returns an unauthorized status code' do
-      code, header, body = verify_request
+      code, _header, _body = verify_request
       expect(code).to eq(401)
     end
   end
@@ -28,7 +26,7 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
     end
 
     it 'returns a 200 ok status code' do
-      code, header, body = verify_request
+      code, _header, _body = verify_request
       expect(code).to eq(200)
     end
   end
@@ -43,27 +41,19 @@ RSpec.describe JWTSignedRequest::Middlewares::Rack do
     end
 
     context 'and request path is not excluded' do
-      let(:env) do
-        {
-          'PATH_INFO' => '/verify'
-        }
-      end
+      let(:env) { {'PATH_INFO' => '/verify'} }
 
       it 'verifies the request' do
-        code, header, body = verify_request
+        verify_request
         expect(JWTSignedRequest).to have_received(:verify)
       end
     end
 
     context 'and request path is excluded' do
-      let(:env) do
-        {
-          'PATH_INFO' => '/health'
-        }
-      end
+      let(:env) { {'PATH_INFO' => '/health'} }
 
       it 'does not verify the request' do
-        code, header, body = verify_request
+        verify_request
         expect(JWTSignedRequest).not_to have_received(:verify)
       end
     end

--- a/spec/jwt_signed_request/sign_spec.rb
+++ b/spec/jwt_signed_request/sign_spec.rb
@@ -12,13 +12,13 @@ module JWTSignedRequest
 
     let(:body) { 'data' }
     let(:private_key) do
-      <<-pem.gsub(/^\s+/, "")
+      <<-PEM.gsub(/^\s+/, "")
         -----BEGIN EC PRIVATE KEY-----
         MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
         AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
         3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
         -----END EC PRIVATE KEY-----
-      pem
+      PEM
     end
 
     let(:secret_key) { OpenSSL::PKey::EC.new(private_key) }

--- a/spec/jwt_signed_request/sign_spec.rb
+++ b/spec/jwt_signed_request/sign_spec.rb
@@ -173,9 +173,9 @@ RSpec.describe JWTSignedRequest::Sign do
     end
   end
 
-  context 'when configured with custom key store' do
+  context 'when configured with named key store' do
     before do
-      JWTSignedRequest.configure_keys('custom-key-store') do |config|
+      JWTSignedRequest.configure_keys('named-key-store') do |config|
         config.add_signing_key(
           key_id: 'my-key-id',
           key: secret_key,
@@ -191,7 +191,7 @@ RSpec.describe JWTSignedRequest::Sign do
         headers: headers,
         body: body,
         key_id: 'my-key-id',
-        key_store_id: 'custom-key-store',
+        key_store_id: 'named-key-store',
       )
     end
 

--- a/spec/jwt_signed_request/sign_spec.rb
+++ b/spec/jwt_signed_request/sign_spec.rb
@@ -3,7 +3,7 @@
 require 'jwt_signed_request'
 
 RSpec.describe JWTSignedRequest::Sign do
-  let(:method) { 'POST'}
+  let(:method) { 'POST' }
   let(:path) { '/api/endpoint' }
   let(:headers) { {'content-type' => 'application/json'} }
   let(:body) { 'data' }
@@ -36,7 +36,7 @@ RSpec.describe JWTSignedRequest::Sign do
         body: body,
         algorithm: algorithm,
         secret_key: secret_key,
-        key_id: 'my-key-id'
+        key_id: 'my-key-id',
       )
     end
 
@@ -49,7 +49,7 @@ RSpec.describe JWTSignedRequest::Sign do
         headers: headers,
         body: body,
         additional_headers_to_sign: nil,
-        issuer: nil
+        issuer: nil,
       )
     end
 
@@ -60,7 +60,7 @@ RSpec.describe JWTSignedRequest::Sign do
         claims,
         secret_key,
         algorithm,
-        kid: 'my-key-id'
+        kid: 'my-key-id',
       )
     end
   end
@@ -84,7 +84,7 @@ RSpec.describe JWTSignedRequest::Sign do
   end
 
   context 'when signing with additional headers' do
-    let(:additional_headers_to_sign) { %w(X-AUTH) }
+    let(:additional_headers_to_sign) { %w[X-AUTH] }
 
     subject(:signed_request) do
       described_class.call(
@@ -93,7 +93,7 @@ RSpec.describe JWTSignedRequest::Sign do
         headers: headers,
         body: body,
         secret_key: secret_key,
-        additional_headers_to_sign: additional_headers_to_sign
+        additional_headers_to_sign: additional_headers_to_sign,
       )
     end
 
@@ -106,7 +106,7 @@ RSpec.describe JWTSignedRequest::Sign do
         headers: headers,
         body: body,
         additional_headers_to_sign: additional_headers_to_sign,
-        issuer: nil
+        issuer: nil,
       )
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe JWTSignedRequest::Sign do
       body: body,
       secret_key: secret_key,
       key_id: 'my-key-id',
-      issuer: 'the-issuer'
+      issuer: 'the-issuer',
     )
 
     expect(JWTSignedRequest::Claims).to have_received(:generate).with(
@@ -128,7 +128,7 @@ RSpec.describe JWTSignedRequest::Sign do
       headers: headers,
       body: body,
       additional_headers_to_sign: nil,
-      issuer: 'the-issuer'
+      issuer: 'the-issuer',
     )
   end
 end

--- a/spec/jwt_signed_request/sign_spec.rb
+++ b/spec/jwt_signed_request/sign_spec.rb
@@ -131,4 +131,45 @@ RSpec.describe JWTSignedRequest::Sign do
       issuer: 'the-issuer',
     )
   end
+
+  context 'when configured with default key store' do
+    before do
+      JWTSignedRequest.configure_keys do |config|
+        config.add_signing_key(
+          key_id: 'my-key-id',
+          key: secret_key,
+          algorithm: 'ES256',
+        )
+      end
+    end
+
+    subject(:sign_request) do
+      described_class.call(
+        method: method,
+        path: path,
+        headers: headers,
+        body: body,
+        key_id: 'my-key-id',
+      )
+    end
+
+    it 'can sign requests without passing secret_key and algorithm', :aggregate_failures do
+      expect(JWTSignedRequest::Claims).to receive(:generate).with(
+        method: method,
+        path: path,
+        headers: headers,
+        body: body,
+        additional_headers_to_sign: nil,
+        issuer: nil,
+      )
+      expect(JWT).to receive(:encode).with(
+        claims,
+        secret_key,
+        'ES256',
+        kid: 'my-key-id',
+      )
+
+      sign_request
+    end
+  end
 end

--- a/spec/jwt_signed_request/sign_spec.rb
+++ b/spec/jwt_signed_request/sign_spec.rb
@@ -2,133 +2,46 @@
 
 require 'jwt_signed_request'
 
-module JWTSignedRequest
-  RSpec.describe Sign do
-    let(:method) { 'POST'}
-    let(:path) { '/api/endpoint' }
-    let(:headers) do
-      { 'content-type' => 'application/json' }
-    end
+RSpec.describe JWTSignedRequest::Sign do
+  let(:method) { 'POST'}
+  let(:path) { '/api/endpoint' }
+  let(:headers) { {'content-type' => 'application/json'} }
+  let(:body) { 'data' }
+  let(:private_key) do
+    <<-PEM.gsub(/^\s+/, "")
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
+      AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
+      3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
+      -----END EC PRIVATE KEY-----
+    PEM
+  end
 
-    let(:body) { 'data' }
-    let(:private_key) do
-      <<-PEM.gsub(/^\s+/, "")
-        -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIBOQ3YIILYMV1glTKbF9oeZWzHe3SNQjAx4IbPIxNygQoAoGCCqGSM49
-        AwEHoUQDQgAEuOC3ufTTnW0hVmCPNERb4LxaDE/OexDdlmXEjHYaixzYIduluGXd
-        3cjg4H2gjqsY/NCpJ9nM8/AAINSrq+qPuA==
-        -----END EC PRIVATE KEY-----
-      PEM
-    end
+  let(:secret_key) { OpenSSL::PKey::EC.new(private_key) }
+  let(:claims) { {secret: 'password'} }
 
-    let(:secret_key) { OpenSSL::PKey::EC.new(private_key) }
-    let(:claims) do
-      {
-        secret: 'password'
-      }
-    end
+  before do
+    allow(JWTSignedRequest::Claims).to receive(:generate).and_return(claims)
+    allow(JWT).to receive(:encode)
+  end
 
-    before do
-      allow(JWTSignedRequest::Claims).to receive(:generate).and_return(claims)
-      allow(JWT).to receive(:encode)
-    end
+  context 'with explicit algorithm' do
+    let(:algorithm) { 'HS256' }
 
-    context 'with explicit algorithm' do
-      let(:algorithm) { 'HS256' }
-
-      subject(:signed_request) do
-        Sign.call(
-          method: method,
-          path: path,
-          headers: headers,
-          body: body,
-          algorithm: algorithm,
-          secret_key: secret_key,
-          key_id: 'my-key-id'
-        )
-      end
-
-      it 'generates a claim using the request' do
-        signed_request
-
-        expect(JWTSignedRequest::Claims).to have_received(:generate).with(
-          method: method,
-          path: path,
-          headers: headers,
-          body: body,
-          additional_headers_to_sign: nil,
-          issuer: nil
-        )
-      end
-
-      it 'signs the claims using the secret key and algorithm' do
-        signed_request
-
-        expect(JWT).to have_received(:encode).with(
-          claims,
-          secret_key,
-          algorithm,
-          kid: 'my-key-id'
-        )
-      end
-    end
-
-    context 'with omitted algorithm' do
-      subject(:signed_request) do
-        Sign.call(
-          method: method,
-          path: path,
-          headers: headers,
-          body: body,
-          secret_key: secret_key,
-        )
-      end
-
-      it 'uses the ES256 algorithm by default' do
-        signed_request
-
-        expect(JWT).to have_received(:encode).with(claims, secret_key, 'ES256', {})
-      end
-    end
-
-    context 'when signing with additional headers' do
-      let(:additional_headers_to_sign) { %w(X-AUTH) }
-
-      subject(:signed_request) do
-        Sign.call(
-          method: method,
-          path: path,
-          headers: headers,
-          body: body,
-          secret_key: secret_key,
-          additional_headers_to_sign: additional_headers_to_sign
-        )
-      end
-
-      it 'signs the claims with the additional headers' do
-        signed_request
-
-        expect(JWTSignedRequest::Claims).to have_received(:generate).with(
-          method: method,
-          path: path,
-          headers: headers,
-          body: body,
-          additional_headers_to_sign: additional_headers_to_sign,
-          issuer: nil
-        )
-      end
-    end
-
-    it 'generates a claim using the request including an issuer' do
-      Sign.call(
+    subject(:signed_request) do
+      described_class.call(
         method: method,
         path: path,
         headers: headers,
         body: body,
+        algorithm: algorithm,
         secret_key: secret_key,
-        key_id: 'my-key-id',
-        issuer: 'the-issuer'
+        key_id: 'my-key-id'
       )
+    end
+
+    it 'generates a claim using the request' do
+      signed_request
 
       expect(JWTSignedRequest::Claims).to have_received(:generate).with(
         method: method,
@@ -136,8 +49,86 @@ module JWTSignedRequest
         headers: headers,
         body: body,
         additional_headers_to_sign: nil,
-        issuer: 'the-issuer'
+        issuer: nil
       )
     end
+
+    it 'signs the claims using the secret key and algorithm' do
+      signed_request
+
+      expect(JWT).to have_received(:encode).with(
+        claims,
+        secret_key,
+        algorithm,
+        kid: 'my-key-id'
+      )
+    end
+  end
+
+  context 'with omitted algorithm' do
+    subject(:signed_request) do
+      described_class.call(
+        method: method,
+        path: path,
+        headers: headers,
+        body: body,
+        secret_key: secret_key,
+      )
+    end
+
+    it 'uses the ES256 algorithm by default' do
+      signed_request
+
+      expect(JWT).to have_received(:encode).with(claims, secret_key, 'ES256', {})
+    end
+  end
+
+  context 'when signing with additional headers' do
+    let(:additional_headers_to_sign) { %w(X-AUTH) }
+
+    subject(:signed_request) do
+      described_class.call(
+        method: method,
+        path: path,
+        headers: headers,
+        body: body,
+        secret_key: secret_key,
+        additional_headers_to_sign: additional_headers_to_sign
+      )
+    end
+
+    it 'signs the claims with the additional headers' do
+      signed_request
+
+      expect(JWTSignedRequest::Claims).to have_received(:generate).with(
+        method: method,
+        path: path,
+        headers: headers,
+        body: body,
+        additional_headers_to_sign: additional_headers_to_sign,
+        issuer: nil
+      )
+    end
+  end
+
+  it 'generates a claim using the request including an issuer' do
+    described_class.call(
+      method: method,
+      path: path,
+      headers: headers,
+      body: body,
+      secret_key: secret_key,
+      key_id: 'my-key-id',
+      issuer: 'the-issuer'
+    )
+
+    expect(JWTSignedRequest::Claims).to have_received(:generate).with(
+      method: method,
+      path: path,
+      headers: headers,
+      body: body,
+      additional_headers_to_sign: nil,
+      issuer: 'the-issuer'
+    )
   end
 end

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -214,5 +214,14 @@ RSpec.describe JWTSignedRequest::Verify do
       verify_request
       expect(request.body.read).to eq 'data=body'
     end
+
+    context 'when secret key and algorithm are unspecified' do
+      subject(:verify_request) { described_class.call(request: request) }
+
+      it 'looks up key store' do
+        expect(JWTSignedRequest.key_store).to receive(:get_verification_key).and_return(double.as_null_object)
+        expect { verify_request }.to raise_error(JWTSignedRequest::UnauthorizedRequestError)
+      end
+    end
   end
 end

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -4,6 +4,22 @@ require 'jwt_signed_request'
 require 'rack'
 
 RSpec.describe JWTSignedRequest::Verify do
+  subject(:verify_request) do
+    described_class.call(request: request, secret_key: secret_key, algorithm: algorithm)
+  end
+
+  let(:request) { Rack::Request.new(request_env) }
+  let(:secret_key) { 'secret' }
+  let(:jwt_token) { 'potato' }
+  let(:algorithm) { 'tomato' }
+  let(:kid) { 'apple' }
+
+  let(:method) { request_env['REQUEST_METHOD'] }
+  let(:path) { request_env['PATH_INFO'] }
+  let(:body) { request_env['rack.input'] }
+  let(:body_sha) { Digest::SHA256.hexdigest(body.string) }
+  let(:headers) { JSON.dump('content-type' => 'application/json') }
+
   let(:request_env) do
     {
       "SERVER_SOFTWARE" => "thin 1.4.1 codename Chromeo",
@@ -35,22 +51,6 @@ RSpec.describe JWTSignedRequest::Verify do
       "SCRIPT_NAME" => "",
       "REMOTE_ADDR" => "127.0.0.1",
     }
-  end
-
-  let(:request) { Rack::Request.new(request_env) }
-  let(:secret_key) { 'secret' }
-  let(:jwt_token) { 'potato' }
-  let(:algorithm) { 'tomato' }
-  let(:kid) { 'apple' }
-
-  let(:method) { request_env['REQUEST_METHOD'] }
-  let(:path) { request_env['PATH_INFO'] }
-  let(:body) { request_env['rack.input'] }
-  let(:body_sha) { Digest::SHA256.hexdigest(body.string) }
-  let(:headers) { JSON.dump('content-type' => 'application/json') }
-
-  subject(:verify_request) do
-    described_class.call(request: request, secret_key: secret_key, algorithm: algorithm)
   end
 
   context 'when request has no Authorization header' do

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -225,8 +225,8 @@ RSpec.describe JWTSignedRequest::Verify do
     end
 
     context 'with custom key store' do
-      subject(:verify_request) { described_class.call(request: request, key_store: custom_key_store) }
-      let(:custom_key_store) { instance_double(JWTSignedRequest::KeyStore) }
+      subject(:verify_request) { described_class.call(request: request, key_store_id: 'custom-key-store') }
+      let(:custom_key_store) { JWTSignedRequest.key_store('custom-key-store') }
 
       it 'looks up custom key store' do
         expect(custom_key_store).to receive(:get_verification_key).and_return(double.as_null_object)

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -224,12 +224,12 @@ RSpec.describe JWTSignedRequest::Verify do
       end
     end
 
-    context 'with custom key store' do
-      subject(:verify_request) { described_class.call(request: request, key_store_id: 'custom-key-store') }
-      let(:custom_key_store) { JWTSignedRequest.key_store('custom-key-store') }
+    context 'with named key store' do
+      subject(:verify_request) { described_class.call(request: request, key_store_id: 'named-key-store') }
+      let(:named_key_store) { JWTSignedRequest.key_store('named-key-store') }
 
-      it 'looks up custom key store' do
-        expect(custom_key_store).to receive(:get_verification_key).and_return(double.as_null_object)
+      it 'looks up named key store' do
+        expect(named_key_store).to receive(:get_verification_key).and_return(double.as_null_object)
         expect { verify_request }.to raise_error(JWTSignedRequest::UnauthorizedRequestError)
       end
     end

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -6,35 +6,34 @@ require 'rack'
 RSpec.describe JWTSignedRequest::Verify do
   let(:request_env) do
     {
-      "SERVER_SOFTWARE"=>"thin 1.4.1 codename Chromeo",
-      "SERVER_NAME"=>"localhost",
-      "rack.input"=>StringIO.new("data=body"),
-      "rack.version"=>[1, 0],
-      "rack.errors"=>"",
-      "rack.multithread"=>false,
-      "rack.multiprocess"=>false,
-      "rack.run_once"=>false,
-      "REQUEST_METHOD"=>"POST",
-      "PATH_INFO"=>"/api/endpoint",
-      "REQUEST_URI"=>"/api/endpoint",
-      "CONTENT_TYPE"=>"application/json",
-      "HTTP_VERSION"=>"HTTP/1.1",
-      "HTTP_HOST"=>"localhost:8080",
-      "HTTP_CONNECTION"=>"keep-alive",
-      "HTTP_ACCEPT"=>"*/*",
-      "HTTP_USER_AGENT"=>
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.47 Safari/536.11",
-        "HTTP_ACCEPT_ENCODING"=>"gzip,deflate,sdch",
-        "HTTP_ACCEPT_LANGUAGE"=>"en-US,en;q=0.8",
-        "HTTP_ACCEPT_CHARSET"=>"ISO-8859-1,utf-8;q=0.7,*;q=0.3",
-        "HTTP_COOKIE"=> "_gauges_unique_year=1;  _gauges_unique_month=1",
-        "GATEWAY_INTERFACE"=>"CGI/1.2",
-        "SERVER_PORT"=>"8080",
-        "QUERY_STRING"=>"",
-        "SERVER_PROTOCOL"=>"HTTP/1.1",
-        "rack.url_scheme"=>"http",
-        "SCRIPT_NAME"=>"",
-        "REMOTE_ADDR"=>"127.0.0.1",
+      "SERVER_SOFTWARE" => "thin 1.4.1 codename Chromeo",
+      "SERVER_NAME" => "localhost",
+      "rack.input" => StringIO.new("data=body"),
+      "rack.version" => [1, 0],
+      "rack.errors" => "",
+      "rack.multithread" => false,
+      "rack.multiprocess" => false,
+      "rack.run_once" => false,
+      "REQUEST_METHOD" => "POST",
+      "PATH_INFO" => "/api/endpoint",
+      "REQUEST_URI" => "/api/endpoint",
+      "CONTENT_TYPE" => "application/json",
+      "HTTP_VERSION" => "HTTP/1.1",
+      "HTTP_HOST" => "localhost:8080",
+      "HTTP_CONNECTION" => "keep-alive",
+      "HTTP_ACCEPT" => "*/*",
+      "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.47 Safari/536.11",
+      "HTTP_ACCEPT_ENCODING" => "gzip,deflate,sdch",
+      "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.8",
+      "HTTP_ACCEPT_CHARSET" => "ISO-8859-1,utf-8;q=0.7,*;q=0.3",
+      "HTTP_COOKIE" => "_gauges_unique_year=1;  _gauges_unique_month=1",
+      "GATEWAY_INTERFACE" => "CGI/1.2",
+      "SERVER_PORT" => "8080",
+      "QUERY_STRING" => "",
+      "SERVER_PROTOCOL" => "HTTP/1.1",
+      "rack.url_scheme" => "http",
+      "SCRIPT_NAME" => "",
+      "REMOTE_ADDR" => "127.0.0.1",
     }
   end
 
@@ -42,7 +41,7 @@ RSpec.describe JWTSignedRequest::Verify do
   let(:secret_key) { 'secret' }
   let(:jwt_token) { 'potato' }
   let(:algorithm) { 'tomato' }
-  let(:kid) { 'apple'}
+  let(:kid) { 'apple' }
 
   let(:method) { request_env['REQUEST_METHOD'] }
   let(:path) { request_env['PATH_INFO'] }
@@ -56,7 +55,7 @@ RSpec.describe JWTSignedRequest::Verify do
 
   context 'when request has no Authorization header' do
     it 'raises a MissingAuthorizationHeaderError' do
-      expect{ verify_request }.to raise_error(JWTSignedRequest::MissingAuthorizationHeaderError)
+      expect { verify_request }.to raise_error(JWTSignedRequest::MissingAuthorizationHeaderError)
     end
   end
 
@@ -76,7 +75,7 @@ RSpec.describe JWTSignedRequest::Verify do
         {
           'alg' => algorithm,
           'kid' => kid,
-        }
+        },
       ]
     end
 
@@ -86,7 +85,7 @@ RSpec.describe JWTSignedRequest::Verify do
 
     context 'and the request matches the JWT claims' do
       it 'does not raise any errors' do
-        expect{ verify_request }.not_to raise_error
+        expect { verify_request }.not_to raise_error
       end
     end
 
@@ -96,7 +95,7 @@ RSpec.describe JWTSignedRequest::Verify do
       end
 
       it 'does not raise any errors' do
-        expect{ verify_request }.not_to raise_error
+        expect { verify_request }.not_to raise_error
       end
     end
 
@@ -104,7 +103,7 @@ RSpec.describe JWTSignedRequest::Verify do
       let(:method) { 'GET' }
 
       it 'raises a RequestMethodVerificationFailedError' do
-        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
+        expect { verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
       end
     end
 
@@ -112,12 +111,12 @@ RSpec.describe JWTSignedRequest::Verify do
       let(:method) { nil }
 
       it 'raises a RequestMethodVerificationFailedError' do
-        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
+        expect { verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
       end
     end
 
     context 'and the request path is different' do
-      let(:path) { '/api/different/endpoint'}
+      let(:path) { '/api/different/endpoint' }
 
       it 'raises a RequestPathVerificationFailedError' do
         expect{ verify_request }.to raise_error(JWTSignedRequest::RequestPathVerificationFailedError)
@@ -126,10 +125,10 @@ RSpec.describe JWTSignedRequest::Verify do
 
     context 'and the request query params are in a different order' do
       before { request_env['QUERY_STRING'] = 'c=3&b=2&a=1' }
-      let(:path) { '/api/endpoint?a=1&b=2&c=3'}
+      let(:path) { '/api/endpoint?a=1&b=2&c=3' }
 
       it 'does not raise any errors' do
-        expect{ verify_request }.not_to raise_error
+        expect { verify_request }.not_to raise_error
       end
     end
 
@@ -137,7 +136,7 @@ RSpec.describe JWTSignedRequest::Verify do
       let(:body_sha) { '1ddfd12592f1090bb0f18a744abe97d07c7adacad3d3a27a9bfa927ff07f7b3c' }
 
       it 'raises a RequestBodyVerificationFailedError' do
-        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestBodyVerificationFailedError)
+        expect { verify_request }.to raise_error(JWTSignedRequest::RequestBodyVerificationFailedError)
       end
     end
 
@@ -145,7 +144,7 @@ RSpec.describe JWTSignedRequest::Verify do
       let(:headers) { JSON.dump('content-type' => 'application/xml') }
 
       it 'raises a RequestHeaderVerificationFailedError' do
-        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestHeaderVerificationFailedError)
+        expect { verify_request }.to raise_error(JWTSignedRequest::RequestHeaderVerificationFailedError)
       end
     end
 
@@ -171,7 +170,7 @@ RSpec.describe JWTSignedRequest::Verify do
           request: request,
           secret_key: secret_key,
           algorithm: algorithm,
-          leeway: 123
+          leeway: 123,
         )
       end
 

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -223,5 +223,15 @@ RSpec.describe JWTSignedRequest::Verify do
         expect { verify_request }.to raise_error(JWTSignedRequest::UnauthorizedRequestError)
       end
     end
+
+    context 'with custom key store' do
+      subject(:verify_request) { described_class.call(request: request, key_store: custom_key_store) }
+      let(:custom_key_store) { instance_double(JWTSignedRequest::KeyStore) }
+
+      it 'looks up custom key store' do
+        expect(custom_key_store).to receive(:get_verification_key).and_return(double.as_null_object)
+        expect { verify_request }.to raise_error(JWTSignedRequest::UnauthorizedRequestError)
+      end
+    end
   end
 end

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -4,10 +4,9 @@ require 'jwt_signed_request'
 require 'rack'
 
 RSpec.describe JWTSignedRequest::Verify do
-  subject(:verify_request) do
-    described_class.call(request: request, secret_key: secret_key, algorithm: algorithm)
-  end
+  subject(:verify_request) { described_class.call(**default_args) }
 
+  let(:default_args) { {request: request, secret_key: secret_key, algorithm: algorithm} }
   let(:request) { Rack::Request.new(request_env) }
   let(:secret_key) { 'secret' }
   let(:jwt_token) { 'potato' }
@@ -165,14 +164,7 @@ RSpec.describe JWTSignedRequest::Verify do
     end
 
     context 'and expiry leeway is provided' do
-      subject(:verify_request) do
-        described_class.call(
-          request: request,
-          secret_key: secret_key,
-          algorithm: algorithm,
-          leeway: 123,
-        )
-      end
+      subject(:verify_request) { described_class.call(**default_args, leeway: 123) }
 
       it 'uses the specified leeway' do
         verify_request
@@ -183,9 +175,7 @@ RSpec.describe JWTSignedRequest::Verify do
     end
 
     context 'and expiry leeway is not provided' do
-      subject(:verify_request) do
-        described_class.call(request: request, secret_key: secret_key, algorithm: algorithm)
-      end
+      subject(:verify_request) { described_class.call(request: request, secret_key: secret_key, algorithm: algorithm) }
 
       it 'does not pass the leeway with options' do
         verify_request
@@ -196,11 +186,9 @@ RSpec.describe JWTSignedRequest::Verify do
     end
 
     context 'and the jwt algorithm is not provided' do
-      let(:algorithm) { nil }
-      subject(:verify_request) do
-        described_class.call(request: request, secret_key: secret_key)
-      end
+      subject(:verify_request) { described_class.call(request: request, secret_key: secret_key) }
 
+      let(:algorithm) { nil }
       context 'and using JWT version 2.x.x' do
         before do
           stub_const("JWT::VERSION::MAJOR", 2)

--- a/spec/jwt_signed_request/verify_spec.rb
+++ b/spec/jwt_signed_request/verify_spec.rb
@@ -3,28 +3,27 @@
 require 'jwt_signed_request'
 require 'rack'
 
-module JWTSignedRequest
-  RSpec.describe Verify do
-    let(:request_env) do
-      {
-        "SERVER_SOFTWARE"=>"thin 1.4.1 codename Chromeo",
-        "SERVER_NAME"=>"localhost",
-        "rack.input"=>StringIO.new("data=body"),
-        "rack.version"=>[1, 0],
-        "rack.errors"=>"",
-        "rack.multithread"=>false,
-        "rack.multiprocess"=>false,
-        "rack.run_once"=>false,
-        "REQUEST_METHOD"=>"POST",
-        "PATH_INFO"=>"/api/endpoint",
-        "REQUEST_URI"=>"/api/endpoint",
-        "CONTENT_TYPE"=>"application/json",
-        "HTTP_VERSION"=>"HTTP/1.1",
-        "HTTP_HOST"=>"localhost:8080",
-        "HTTP_CONNECTION"=>"keep-alive",
-        "HTTP_ACCEPT"=>"*/*",
-        "HTTP_USER_AGENT"=>
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.47 Safari/536.11",
+RSpec.describe JWTSignedRequest::Verify do
+  let(:request_env) do
+    {
+      "SERVER_SOFTWARE"=>"thin 1.4.1 codename Chromeo",
+      "SERVER_NAME"=>"localhost",
+      "rack.input"=>StringIO.new("data=body"),
+      "rack.version"=>[1, 0],
+      "rack.errors"=>"",
+      "rack.multithread"=>false,
+      "rack.multiprocess"=>false,
+      "rack.run_once"=>false,
+      "REQUEST_METHOD"=>"POST",
+      "PATH_INFO"=>"/api/endpoint",
+      "REQUEST_URI"=>"/api/endpoint",
+      "CONTENT_TYPE"=>"application/json",
+      "HTTP_VERSION"=>"HTTP/1.1",
+      "HTTP_HOST"=>"localhost:8080",
+      "HTTP_CONNECTION"=>"keep-alive",
+      "HTTP_ACCEPT"=>"*/*",
+      "HTTP_USER_AGENT"=>
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.47 Safari/536.11",
         "HTTP_ACCEPT_ENCODING"=>"gzip,deflate,sdch",
         "HTTP_ACCEPT_LANGUAGE"=>"en-US,en;q=0.8",
         "HTTP_ACCEPT_CHARSET"=>"ISO-8859-1,utf-8;q=0.7,*;q=0.3",
@@ -36,198 +35,197 @@ module JWTSignedRequest
         "rack.url_scheme"=>"http",
         "SCRIPT_NAME"=>"",
         "REMOTE_ADDR"=>"127.0.0.1",
-      }
+    }
+  end
+
+  let(:request) { Rack::Request.new(request_env) }
+  let(:secret_key) { 'secret' }
+  let(:jwt_token) { 'potato' }
+  let(:algorithm) { 'tomato' }
+  let(:kid) { 'apple'}
+
+  let(:method) { request_env['REQUEST_METHOD'] }
+  let(:path) { request_env['PATH_INFO'] }
+  let(:body) { request_env['rack.input'] }
+  let(:body_sha) { Digest::SHA256.hexdigest(body.string) }
+  let(:headers) { JSON.dump('content-type' => 'application/json') }
+
+  subject(:verify_request) do
+    described_class.call(request: request, secret_key: secret_key, algorithm: algorithm)
+  end
+
+  context 'when request has no Authorization header' do
+    it 'raises a MissingAuthorizationHeaderError' do
+      expect{ verify_request }.to raise_error(JWTSignedRequest::MissingAuthorizationHeaderError)
+    end
+  end
+
+  context 'when there is an Authorization header set' do
+    let(:request) do
+      Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}"}))
     end
 
-    let(:request) { Rack::Request.new(request_env) }
-    let(:secret_key) { 'secret' }
-    let(:jwt_token) { 'potato' }
-    let(:algorithm) { 'tomato' }
-    let(:kid) { 'apple'}
-
-    let(:method) { request_env['REQUEST_METHOD'] }
-    let(:path) { request_env['PATH_INFO'] }
-    let(:body) { request_env['rack.input'] }
-    let(:body_sha) { Digest::SHA256.hexdigest(body.string) }
-    let(:headers) { JSON.dump('content-type' => 'application/json') }
-
-    subject(:verify_request) do
-      Verify.call(request: request, secret_key: secret_key, algorithm: algorithm)
+    let(:claims) do
+      [
+        {
+          'method' => method,
+          'path' => path,
+          'body_sha' => body_sha,
+          'headers' => headers,
+        },
+        {
+          'alg' => algorithm,
+          'kid' => kid,
+        }
+      ]
     end
 
-    context 'when request has no Authorization header' do
-      it 'raises a MissingAuthorizationHeaderError' do
-        expect{ verify_request }.to raise_error(JWTSignedRequest::MissingAuthorizationHeaderError)
+    before do
+      allow(JWT).to receive(:decode).and_return(claims)
+    end
+
+    context 'and the request matches the JWT claims' do
+      it 'does not raise any errors' do
+        expect{ verify_request }.not_to raise_error
       end
     end
 
-    context 'when there is an Authorization header set' do
+    context 'and signed without an authorization bearer syntax' do
       let(:request) do
-        Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => "Bearer #{jwt_token}"}))
+        Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => jwt_token}))
       end
 
-      let(:claims) do
-        [
-          {
-            'method' => method,
-            'path' => path,
-            'body_sha' => body_sha,
-            'headers' => headers,
-          },
-          {
-            'alg' => algorithm,
-            'kid' => kid,
-          }
-        ]
+      it 'does not raise any errors' do
+        expect{ verify_request }.not_to raise_error
+      end
+    end
+
+    context 'and the request method is different' do
+      let(:method) { 'GET' }
+
+      it 'raises a RequestMethodVerificationFailedError' do
+        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
+      end
+    end
+
+    context 'and there is no request method in the claims' do
+      let(:method) { nil }
+
+      it 'raises a RequestMethodVerificationFailedError' do
+        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
+      end
+    end
+
+    context 'and the request path is different' do
+      let(:path) { '/api/different/endpoint'}
+
+      it 'raises a RequestPathVerificationFailedError' do
+        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestPathVerificationFailedError)
+      end
+    end
+
+    context 'and the request query params are in a different order' do
+      before { request_env['QUERY_STRING'] = 'c=3&b=2&a=1' }
+      let(:path) { '/api/endpoint?a=1&b=2&c=3'}
+
+      it 'does not raise any errors' do
+        expect{ verify_request }.not_to raise_error
+      end
+    end
+
+    context 'and the body is different' do
+      let(:body_sha) { '1ddfd12592f1090bb0f18a744abe97d07c7adacad3d3a27a9bfa927ff07f7b3c' }
+
+      it 'raises a RequestBodyVerificationFailedError' do
+        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestBodyVerificationFailedError)
+      end
+    end
+
+    context 'and the request headers are different' do
+      let(:headers) { JSON.dump('content-type' => 'application/xml') }
+
+      it 'raises a RequestHeaderVerificationFailedError' do
+        expect{ verify_request }.to raise_error(JWTSignedRequest::RequestHeaderVerificationFailedError)
+      end
+    end
+
+    context 'and there are no headers in the claims' do
+      let(:headers) { nil }
+
+      it 'does not raise an error' do
+        expect { verify_request }.to_not raise_error
+      end
+    end
+
+    context 'and the headers are invalid JSON in the claim' do
+      let(:headers) { 'invalid' }
+
+      it 'does not raise an error' do
+        expect { verify_request }.to_not raise_error
+      end
+    end
+
+    context 'and expiry leeway is provided' do
+      subject(:verify_request) do
+        described_class.call(
+          request: request,
+          secret_key: secret_key,
+          algorithm: algorithm,
+          leeway: 123
+        )
       end
 
-      before do
-        allow(JWT).to receive(:decode).and_return(claims)
-      end
-
-      context 'and the request matches the JWT claims' do
-        it 'does not raise any errors' do
-          expect{ verify_request }.not_to raise_error
-        end
-      end
-
-      context 'and signed without an authorization bearer syntax' do
-        let(:request) do
-          Rack::Request.new(request_env.merge({'HTTP_AUTHORIZATION' => jwt_token}))
-        end
-
-        it 'does not raise any errors' do
-          expect{ verify_request }.not_to raise_error
-        end
-      end
-
-      context 'and the request method is different' do
-        let(:method) { 'GET' }
-
-        it 'raises a RequestMethodVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
-        end
-      end
-
-      context 'and there is no request method in the claims' do
-        let(:method) { nil }
-
-        it 'raises a RequestMethodVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestMethodVerificationFailedError)
-        end
-      end
-
-      context 'and the request path is different' do
-        let(:path) { '/api/different/endpoint'}
-
-        it 'raises a RequestPathVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestPathVerificationFailedError)
-        end
-      end
-
-      context 'and the request query params are in a different order' do
-        before { request_env['QUERY_STRING'] = 'c=3&b=2&a=1' }
-        let(:path) { '/api/endpoint?a=1&b=2&c=3'}
-
-        it 'does not raise any errors' do
-          expect{ verify_request }.not_to raise_error
-        end
-      end
-
-      context 'and the body is different' do
-        let(:body_sha) { '1ddfd12592f1090bb0f18a744abe97d07c7adacad3d3a27a9bfa927ff07f7b3c' }
-
-        it 'raises a RequestBodyVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestBodyVerificationFailedError)
-        end
-      end
-
-      context 'and the request headers are different' do
-        let(:headers) { JSON.dump('content-type' => 'application/xml') }
-
-        it 'raises a RequestHeaderVerificationFailedError' do
-          expect{ verify_request }.to raise_error(JWTSignedRequest::RequestHeaderVerificationFailedError)
-        end
-      end
-
-      context 'and there are no headers in the claims' do
-        let(:headers) { nil }
-
-        it 'does not raise an error' do
-          expect { verify_request }.to_not raise_error
-        end
-      end
-
-      context 'and the headers are invalid JSON in the claim' do
-        let(:headers) { 'invalid' }
-
-        it 'does not raise an error' do
-          expect { verify_request }.to_not raise_error
-        end
-      end
-
-      context 'and expiry leeway is provided' do
-        subject(:verify_request) do
-          Verify.call(
-            request: request,
-            secret_key: secret_key,
-            algorithm: algorithm,
-            leeway: 123
-          )
-        end
-
-        it 'uses the specified leeway' do
-          verify_request
-          expect(JWT).to have_received(:decode).with(
-            jwt_token, secret_key, true, leeway: 123, algorithm: algorithm
-          )
-        end
-      end
-
-      context 'and expiry leeway is not provided' do
-        subject(:verify_request) do
-          Verify.call(request: request, secret_key: secret_key, algorithm: algorithm)
-        end
-
-        it 'does not pass the leeway with options' do
-          verify_request
-          expect(JWT).to have_received(:decode).with(
-            jwt_token, secret_key, true, algorithm: algorithm
-          )
-        end
-      end
-
-      context 'and the jwt algorithm is not provided' do
-        let(:algorithm) { nil }
-        subject(:verify_request) do
-          Verify.call(request: request, secret_key: secret_key)
-        end
-
-        context 'and using JWT version 2.x.x' do
-          before do
-            stub_const("JWT::VERSION::MAJOR", 2)
-          end
-
-          it 'raises an a MissingAlgorithmError' do
-            expect { verify_request }.to raise_error(JWTSignedRequest::MissingAlgorithmError)
-          end
-        end
-
-        context 'and using JWT version 1.x.x' do
-          before do
-            stub_const("JWT::VERSION::MAJOR", 1)
-          end
-
-          it 'does not raise a MissingAlgorithmError' do
-            expect { verify_request }.to_not raise_error
-          end
-        end
-      end
-
-      it 'allows the body to be read' do
+      it 'uses the specified leeway' do
         verify_request
-        expect(request.body.read).to eq 'data=body'
+        expect(JWT).to have_received(:decode).with(
+          jwt_token, secret_key, true, leeway: 123, algorithm: algorithm
+        )
       end
+    end
+
+    context 'and expiry leeway is not provided' do
+      subject(:verify_request) do
+        described_class.call(request: request, secret_key: secret_key, algorithm: algorithm)
+      end
+
+      it 'does not pass the leeway with options' do
+        verify_request
+        expect(JWT).to have_received(:decode).with(
+          jwt_token, secret_key, true, algorithm: algorithm
+        )
+      end
+    end
+
+    context 'and the jwt algorithm is not provided' do
+      let(:algorithm) { nil }
+      subject(:verify_request) do
+        described_class.call(request: request, secret_key: secret_key)
+      end
+
+      context 'and using JWT version 2.x.x' do
+        before do
+          stub_const("JWT::VERSION::MAJOR", 2)
+        end
+
+        it 'raises an a MissingAlgorithmError' do
+          expect { verify_request }.to raise_error(JWTSignedRequest::MissingAlgorithmError)
+        end
+      end
+
+      context 'and using JWT version 1.x.x' do
+        before do
+          stub_const("JWT::VERSION::MAJOR", 1)
+        end
+
+        it 'does not raise a MissingAlgorithmError' do
+          expect { verify_request }.to_not raise_error
+        end
+      end
+    end
+
+    it 'allows the body to be read' do
+      verify_request
+      expect(request.body.read).to eq 'data=body'
     end
   end
 end

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe JWTSignedRequest do
   describe '.sign' do
     it 'calls the Sign class' do
       arguments = { arg: double }
-      expect(JWTSignedRequest::Sign).to receive(:call).with(arguments)
-      JWTSignedRequest.sign(**arguments)
+      expect(described_class::Sign).to receive(:call).with(arguments)
+      described_class.sign(**arguments)
     end
   end
 
   describe '.verify' do
     it 'calls the Verify class' do
       arguments = { arg: double }
-      expect(JWTSignedRequest::Verify).to receive(:call).with(arguments)
-      JWTSignedRequest.verify(**arguments)
+      expect(described_class::Verify).to receive(:call).with(arguments)
+      described_class.verify(**arguments)
     end
   end
 end

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe JWTSignedRequest do
 
     context 'with custom key store' do
       it 'adds verification keys to the custom key store' do
-        custom_key_store = described_class.key_stores['some key store ID']
+        custom_key_store = described_class.key_store('some key store ID')
         key = double
         expect(custom_key_store).to receive(:add_verification_key).with(key)
         described_class.configure_keys('some key store ID') do |config|

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe JWTSignedRequest do
         config.add_verification_key(key)
       end
     end
+
+    context 'with custom key store' do
+      it 'adds verification keys to the custom key store' do
+        custom_key_store = described_class.key_stores['some key store ID']
+        key = double
+        expect(custom_key_store).to receive(:add_verification_key).with(key)
+        described_class.configure_keys('some key store ID') do |config|
+          config.add_verification_key(key)
+        end
+      end
+    end
   end
 
   describe '.sign' do

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -3,6 +3,16 @@
 require 'jwt_signed_request'
 
 RSpec.describe JWTSignedRequest do
+  describe '.configure_keys' do
+    it 'adds verification keys to the default key store' do
+      key = double
+      expect(described_class.key_store).to receive(:add_verification_key).with(key)
+      described_class.configure_keys do |config|
+        config.add_verification_key(key)
+      end
+    end
+  end
+
   describe '.sign' do
     it 'calls the Sign class' do
       arguments = { arg: double }

--- a/spec/jwt_signed_request_spec.rb
+++ b/spec/jwt_signed_request_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe JWTSignedRequest do
       end
     end
 
-    context 'with custom key store' do
-      it 'adds verification keys to the custom key store' do
-        custom_key_store = described_class.key_store('some key store ID')
+    context 'with named key store' do
+      it 'adds verification keys to the named key store' do
+        named_key_store = described_class.key_store('some key store ID')
         key = double
-        expect(custom_key_store).to receive(:add_verification_key).with(key)
+        expect(named_key_store).to receive(:add_verification_key).with(key)
         described_class.configure_keys('some key store ID') do |config|
           config.add_verification_key(key)
         end


### PR DESCRIPTION
## Context

Some applications need finer grained control for request verification. 

Currently this gem supports a single (global) key store. 

## Change

- Add support for multiple key stores (backwards compatible; defaults to current behaviour). 
- Add optional `key_store_id` kwarg option to `.sign` and `.verify`. 
- Support optional `key_store_id` in Faraday and Rack middleware. 

These changes are documented in the README, but here are the related changes for multiple key stores:

```ruby
# Configure named key store
key_store_id = 'widget_admin' # optional arg; preserves current behaviour when omitted
JWTSignedRequest.configure_keys(key_store_id) do |config|
  config.add_signing_key(
    key_id: 'client_a',
    key: OpenSSL::PKey::EC.new(private_key),
    algorithm: 'ES256',
  )
  config.add_verification_key(
    key_id: 'client_a',
    key: OpenSSL::PKey::EC.new(public_key),
    algorithm: 'ES256',
  )
end

# Sign request from named key store
jwt_token = JWTSignedRequest.sign(
  method: req.method,
  path: req.path,
  headers: {"Content-Type" => "application/json"},
  body: "",
  key_id: 'my-key-id',
  key_store_id: 'widget_admin', # optional
)

# Verify request from named key store
JWTSignedRequest.verify(
  request: request,
  key_store_id: 'widget_admin', # optional
)
```