### PR TITLE
Make the faraday middleware compatible with faraday 1.2.0

### DIFF
--- a/lib/jwt_signed_request/middlewares/faraday.rb
+++ b/lib/jwt_signed_request/middlewares/faraday.rb
@@ -8,8 +8,7 @@ module JWTSignedRequest
     class Faraday < Faraday::Middleware
       def initialize(app, bearer_schema: nil, **options)
         @bearer_schema = bearer_schema
-        @options = options
-        super(app)
+        super(app, options)
       end
 
       def call(env)


### PR DESCRIPTION
The faraday middleware has changed the way it works in 1.2.0:

https://github.com/lostisland/faraday/compare/v1.1.0..v1.2.0#diff-7069feb3b4134ee202fcb2213a2fa46f54fd94fd66ad032e95c305c871d7eedf

It will now clobber the `@options` instance variable set in subclasses. Instead
options have to be passed to the superclass middleware constructor.
