### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
         gemfile: [ 'faraday_1.10.0', 'faraday_2.1.0', 'faraday_2.2.0', 'faraday_2.3.0', 'jwt_1.5.6', 'jwt_2.2.3', 'jwt_2.3.0', 'jwt_2.4.1' ]
         exclude:
           - { ruby: '2.4', gemfile: 'faraday_2.1.0' }
@@ -21,11 +21,12 @@ jobs:
           - { ruby: '3.0', gemfile: 'faraday_1.10.0' }
           - { ruby: '3.1', gemfile: 'faraday_1.10.0' }
           - { ruby: '3.2', gemfile: 'faraday_1.10.0' }
+          - { ruby: '3.3', gemfile: 'faraday_1.10.0' }
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Ruby 3.3 has [been released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.