### PR TITLE
Added workflow for autoclosing "stale" PRs and issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+## What Changed
+
+
+## Heads up!
+
+PRs that go 60 days without activity may be automatically closed. See [these docs](https://github.com/envato/jwt_signed_request?tab=readme-ov-file#stale-prs) for more information.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+# This workflow warns and then closes PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Label and close stale pull requests
+
+on:
+  schedule:
+  - cron: '0 0 * * *' # daily at midnight
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has had no activity for 60 days and is now considered stale. It will be closed in 7 days if there is no further activity.'
+        stale-issue-label: 'stale-issue'
+        stale-pr-message: 'This pull request has had no activity for 60 days and is now considered stale. It will be closed in 7 days if there is no further activity.'
+        stale-pr-label: 'stale-pr'
+        days-before-stale: 60
+        days-before-close: 7 # Will be closed 7 days after being labelled if there is no further activity in that time
+        exempt-issue-labels: 'do-not-auto-close' # allows us to allowlist issues that have a valid reason for no activity over a long period of time
+        exempt-pr-labels: 'do-not-auto-close' # allows us to allowlist PRs that have a valid reason for no activity over a long period of time

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ then run:
 $ bundle
 ```
 
+## Stale PRs
+
+We use the "stale" workflow to manage our PRs.
+If you have a PR open for 60 days without any activity, it will automatically be labelled `stale-pr`.
+If there is no activity for 7 days after this label is applied, the PR will be automatically closed.
+
+If you have a PR that has a sensible reason for being open for a long period of time with no activity, you can apply the `do-not-auto-close` label to avoid it being automatically closed.
+
 ## Generating EC Keys
 
 We should be using a public key encryption algorithm such as **ES256**. To generate your public/private key pair using **ES256** run:


### PR DESCRIPTION
## Context

In an effort to keep our repositories clean, Acquisition Essential is adding the "stale" workflow to close old PRs and issues.
PRs and issues that are 60 days old will first be labelled with `stale-pr` or `stale-issue` and if there is no further activity in the following 7 days, will be automatically closed.

[Trello card](https://trello.com/c/aeckPgFS/6404-shield-improvement-automate-closing-old-prs)

I also added a basic PR template so that we can warn peeps of the stale PR functionality.

## Considerations

Once merged I will:
- Create the new `do-not-auto-close` label
- Tag any PR owners who currently have old PRs open to notify them of their impending closure (so they can decide how to action them)
